### PR TITLE
Simplify system dependency linking logic

### DIFF
--- a/src/subcommands/generate/ld_path.cpp
+++ b/src/subcommands/generate/ld_path.cpp
@@ -337,7 +337,7 @@ void write_variables(const YAML::Node &profile, std::ofstream &buildfile,
               // << "builddir = " << build_dir.string() << "\n"
               // << "objdir = " << obj_dir.string() << "\n"
               << "ldflags = " << ldflags << " \n"
-              << "ldlibs= " << ldlibs << "\n\n"; // place compiled libraries here
+              << "ldlibs = " << ldlibs << "\n\n"; // place compiled libraries here
 }
 
 void write_rules(std::ofstream &buildfile) {


### PR DESCRIPTION
Remove the requirement for explicit include/lib paths to be present before
adding the library link flag (`-l{name}`). The link flag is now added whenever
the linkage type is "static" or "shared", regardless of custom path
configuration.
