### PR TITLE
feat: implement lock subcommand and lockfile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ dependencies:
 | `catalyst init` | Create a new project |
 | `catalyst build` | Build the project |
 | `catalyst run` | Run the binary |
+| `catalyst lock` | Pin dependencies |
 | `catalyst add` | Add a dependency |
 
 For a full list, see the **[CLI Reference](docs/cli/index.md)**.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -13,6 +13,7 @@ Catalyst provides a suite of subcommands to manage the entire project lifecycle.
 | [`fetch`](fetch.md) | Fetch remote dependencies. |
 | [`generate`](generate.md) | Generate build scripts (Ninja, Make, etc.). |
 | [`install`](install.md) | Install build artifacts. |
+| [`lock`](lock.md) | Pin dependency versions to a lockfile. |
 | [`clean`](clean.md) | Remove build artifacts. |
 | [`download`](download.md) | Download, build, and install a project from git. |
 | [`fmt`](fmt.md) | Format source code. |

--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -1,0 +1,32 @@
+# catalyst lock
+
+```
+Resolve and pin dependencies to a catalyst.lock file.
+Usage: catalyst lock [OPTIONS]
+
+Options:
+  -h,--help                   Print this help message and exit
+  -p,--profiles TEXT ...      Profile composition to use for dependency resolution.
+```
+
+## Details
+
+The `lock` command resolves all dependencies declared in your `catalyst.yaml` (and workspace member manifests) to specific, reproducible states.
+
+- **Git**: Resolves branches, tags, or "latest" to specific 40-character commit hashes using `git ls-remote`.
+- **Vcpkg**: Records the version and triplet.
+- **System/Local**: Records the source type and paths.
+
+In a **Workspace**, a single `catalyst.lock` is generated at the workspace root, containing a consolidated set of pinned dependencies for all workspace members.
+
+Running `catalyst fetch` or `catalyst build` will automatically detect and use the `catalyst.lock` file if it exists, ensuring that everyone on your team and your CI/CD pipelines use the exact same dependency versions.
+
+## Examples
+
+```bash
+# Resolve and pin dependencies for the current project
+catalyst lock
+
+# Resolve dependencies using specific profiles
+catalyst lock --profiles debug release
+```

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -81,3 +81,14 @@ You can use the [`catalyst add`](../cli/add.md) command to append dependencies t
 catalyst add git https://github.com/fmtlib/fmt.git -v 10.0.0
 catalyst add vcpkg nlohmann-json -t x64-linux
 ```
+
+## Reproducible Builds with Lockfiles
+
+Catalyst supports pinning dependency versions to ensure that everyone working on a project uses the exact same revisions.
+
+By running [`catalyst lock`](../cli/lock.md), you generate a `catalyst.lock` file. This file pins:
+- **Git** dependencies to specific 40-character commit hashes.
+- **Vcpkg** dependencies to their current versions and triplets.
+- **Local/System** dependencies to their paths.
+
+When a `catalyst.lock` is present, `catalyst fetch` and `catalyst build` will prioritize its contents over the loose version constraints in `catalyst.yaml`.

--- a/docs/concepts/workspaces.md
+++ b/docs/concepts/workspaces.md
@@ -56,6 +56,12 @@ a `WORKSPACE.yaml` file.
 When resolving dependencies, Catalyst can look up packages within the active workspace. This allows members to depend
 on each other without needing to specify hardcoded relative paths or publish to a remote registry during development.
 
+## Consolidated Lockfiles
+
+In a workspace, running [`catalyst lock`](../cli/lock.md) will generate a single `catalyst.lock` at the workspace root. This consolidated lockfile contains the resolved and pinned dependencies for **all** workspace members defined in `WORKSPACE.yaml`.
+
+This ensures that version consistency is maintained across the entire workspace, and any external dependencies used by multiple members are pinned to the same version.
+
 ## Use Cases
 
 - Monorepos: Manage all your microservices or library sets in one place.

--- a/include/catalyst/dispatch.hpp
+++ b/include/catalyst/dispatch.hpp
@@ -13,6 +13,7 @@
 #include "catalyst/subcommands/ide_sync.hpp"
 #include "catalyst/subcommands/init.hpp"
 #include "catalyst/subcommands/install.hpp"
+#include "catalyst/subcommands/lock.hpp"
 #include "catalyst/subcommands/pack.hpp"
 #include "catalyst/subcommands/run.hpp"
 #include "catalyst/subcommands/test.hpp"
@@ -55,6 +56,9 @@ struct CliContext {
 
     CLI::App *install_subc{nullptr};
     std::unique_ptr<catalyst::install::Parse> install_res{nullptr};
+
+    CLI::App *lock_subc{nullptr};
+    std::unique_ptr<catalyst::lock::Parse> lock_res{nullptr};
 
     CLI::App *run_subc{nullptr};
     std::unique_ptr<catalyst::run::Parse> run_res{nullptr};

--- a/include/catalyst/subcommands/lock.hpp
+++ b/include/catalyst/subcommands/lock.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <expected>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <CLI/App.hpp>
+
+#include "catalyst/workspace.hpp"
+
+namespace catalyst::lock {
+struct Parse {
+    std::vector<std::string> profiles;
+    std::optional<catalyst::Workspace> workspace;
+};
+
+std::pair<CLI::App *, std::unique_ptr<Parse>> parse(CLI::App &app);
+std::expected<void, std::string> action(const Parse &parse_args);
+} // namespace catalyst::lock

--- a/src/catalyst.cpp
+++ b/src/catalyst.cpp
@@ -28,14 +28,17 @@ int main(int argc, char **argv) {
     if (should_return)
         return exit_code;
 
-    auto assign_ws_if = [&ctx](auto &res) {
-        if (res)
+    auto assign_ws_if = [&ctx](auto *subc, auto &res) {
+        if (subc && *subc) {
             res->workspace = ctx.workspace;
-        return static_cast<bool>(res);
+            return true;
+        }
+        return false;
     };
 
-    assign_ws_if(ctx.bench_res) || assign_ws_if(ctx.build_res) || assign_ws_if(ctx.clean_res) ||
-        assign_ws_if(ctx.fetch_res) || assign_ws_if(ctx.lock_res) || assign_ws_if(ctx.test_res);
+    assign_ws_if(ctx.bench_subc, ctx.bench_res) || assign_ws_if(ctx.build_subc, ctx.build_res) ||
+        assign_ws_if(ctx.clean_subc, ctx.clean_res) || assign_ws_if(ctx.fetch_subc, ctx.fetch_res) ||
+        assign_ws_if(ctx.lock_subc, ctx.lock_res) || assign_ws_if(ctx.test_subc, ctx.test_res);
 
     if (ctx.show_version) {
         std::println("{}", catalyst::CATALYST_VERSION);

--- a/src/catalyst.cpp
+++ b/src/catalyst.cpp
@@ -28,16 +28,17 @@ int main(int argc, char **argv) {
     if (should_return)
         return exit_code;
 
-    if (ctx.build_res)
-        ctx.build_res->workspace = ctx.workspace;
-    if (ctx.fetch_res)
-        ctx.fetch_res->workspace = ctx.workspace;
-    if (ctx.test_res)
-        ctx.test_res->workspace = ctx.workspace;
-    if (ctx.bench_res)
-        ctx.bench_res->workspace = ctx.workspace;
-    if (ctx.clean_res)
-        ctx.clean_res->workspace = ctx.workspace;
+    auto assign_ws_if = [&ctx](auto &res) {
+        if (res)
+            res->workspace = ctx.workspace;
+    };
+
+    assign_ws_if(ctx.bench_res);
+    assign_ws_if(ctx.build_res);
+    assign_ws_if(ctx.clean_res);
+    assign_ws_if(ctx.fetch_res);
+    assign_ws_if(ctx.lock_res);
+    assign_ws_if(ctx.test_res);
 
     if (ctx.show_version) {
         std::println("{}", catalyst::CATALYST_VERSION);

--- a/src/catalyst.cpp
+++ b/src/catalyst.cpp
@@ -31,14 +31,11 @@ int main(int argc, char **argv) {
     auto assign_ws_if = [&ctx](auto &res) {
         if (res)
             res->workspace = ctx.workspace;
+        return static_cast<bool>(res);
     };
 
-    assign_ws_if(ctx.bench_res);
-    assign_ws_if(ctx.build_res);
-    assign_ws_if(ctx.clean_res);
-    assign_ws_if(ctx.fetch_res);
-    assign_ws_if(ctx.lock_res);
-    assign_ws_if(ctx.test_res);
+    assign_ws_if(ctx.bench_res) || assign_ws_if(ctx.build_res) || assign_ws_if(ctx.clean_res) ||
+        assign_ws_if(ctx.fetch_res) || assign_ws_if(ctx.lock_res) || assign_ws_if(ctx.test_res);
 
     if (ctx.show_version) {
         std::println("{}", catalyst::CATALYST_VERSION);

--- a/src/dispatch.cpp
+++ b/src/dispatch.cpp
@@ -48,7 +48,6 @@ std::pair<int, bool> parseCli(int argc, char **argv, catalyst::CliContext &ctx) 
     tie(ctx.bench_subc, ctx.bench_res) = catalyst::bench::parse(ctx.app);
     tie(ctx.tidy_subc, ctx.tidy_res) = catalyst::tidy::parse(ctx.app);
     tie(ctx.pack_subc, ctx.pack_res) = catalyst::pack::parse(ctx.app);
-    // tie(ctx.bench_subc, ctx.bench_res) = catalyst::bench::parse(ctx.app);
     tie(ctx.doc_subc, ctx.doc_res) = catalyst::doc::parse(ctx.app);
     tie(ctx.add_git_subc, ctx.add_git_res) = catalyst::add::git::parse(*ctx.add_subc);
     tie(ctx.add_system_subc, ctx.add_system_res) = catalyst::add::system::parse(*ctx.add_subc);

--- a/src/dispatch.cpp
+++ b/src/dispatch.cpp
@@ -124,8 +124,6 @@ int dispatch(const catalyst::CliContext &ctx) {
         return dispatchFN("tidy", *ctx.tidy_res, catalyst::tidy::action);
     if (*ctx.pack_subc)
         return dispatchFN("pack", *ctx.pack_res, catalyst::pack::action);
-    // if (*ctx.bench_subc)
-    //     return dispatchFN("bench", *ctx.bench_res, catalyst::bench::action);
     if (*ctx.doc_subc)
         return dispatchFN("doc", *ctx.doc_res, catalyst::doc::action);
     catalyst::logger.log(catalyst::LogLevel::ERROR, "run catalyst --help for info on available commands.");

--- a/src/dispatch.cpp
+++ b/src/dispatch.cpp
@@ -42,6 +42,7 @@ std::pair<int, bool> parseCli(int argc, char **argv, catalyst::CliContext &ctx) 
     tie(ctx.ide_sync_subc, ctx.ide_sync_res) = catalyst::ide_sync::parse(ctx.app);
     tie(ctx.init_subc, ctx.init_res) = catalyst::init::parse(ctx.app);
     tie(ctx.install_subc, ctx.install_res) = catalyst::install::parse(ctx.app);
+    tie(ctx.lock_subc, ctx.lock_res) = catalyst::lock::parse(ctx.app);
     tie(ctx.run_subc, ctx.run_res) = catalyst::run::parse(ctx.app);
     tie(ctx.test_subc, ctx.test_res) = catalyst::test::parse(ctx.app);
     tie(ctx.bench_subc, ctx.bench_res) = catalyst::bench::parse(ctx.app);
@@ -114,6 +115,8 @@ int dispatch(const catalyst::CliContext &ctx) {
         return dispatchFN("init", *ctx.init_res, catalyst::init::action);
     if (*ctx.install_subc)
         return dispatchFN("install", *ctx.install_res, catalyst::install::action);
+    if (*ctx.lock_subc)
+        return dispatchFN("lock", *ctx.lock_res, catalyst::lock::action);
     if (*ctx.run_subc)
         return dispatchFN("run", *ctx.run_res, catalyst::run::action);
     if (*ctx.test_subc)

--- a/src/subcommands/fetch/action.cpp
+++ b/src/subcommands/fetch/action.cpp
@@ -44,28 +44,46 @@ std::expected<void, std::string> fetchVcpkg(const std::string &name) {
 }
 
 std::expected<void, std::string>
-fetchGit(std::string build_dir, std::string name, std::string source, std::string version) {
-    catalyst::logger.log(LogLevel::DEBUG, "Fetching git dependency: {}@{} from {}", name, version, source);
+fetchGit(std::string build_dir, std::string name, std::string source, std::string version, std::string hash = "") {
+    catalyst::logger.log(LogLevel::DEBUG, "Fetching git dependency: {}@{} (hash: {}) from {}", name, version, hash, source);
     fs::path dep_path = fs::path(build_dir) / "catalyst-libs" / name;
-    std::println(std::cout, "Fetching: {}@{} from {}", name, version, source);
-    std::string command;
-    std::vector<std::string> args = {"git", "clone", "--depth", "1"};
-    if (version == "latest") {
-        command = std::format("git clone --depth 1 {} {}", source, dep_path.string());
-        args.push_back(source);
-        args.push_back(dep_path.string());
+    
+    std::string target = hash.empty() ? version : hash;
+    std::println(std::cout, "Fetching: {}@{} from {}", name, target, source);
+    
+    std::vector<std::string> args;
+    if (hash.empty()) {
+        args = {"git", "clone", "--depth", "1"};
+        if (version == "latest") {
+            args.push_back(source);
+            args.push_back(dep_path.string());
+        } else {
+            args.push_back("--branch");
+            args.push_back(version);
+            args.push_back(source);
+            args.push_back(dep_path.string());
+        }
+        if (catalyst::processExec(std::move(args)).value().get() != 0) {
+            catalyst::logger.log(LogLevel::ERROR, "Failed to fetch dependency: {}", name);
+            return std::unexpected(std::format("Failed to fetch dependency: {}", name));
+        }
     } else {
-        command = std::format("git clone --depth 1 --branch {} {} {}", version, source, dep_path.string());
-        args.push_back("--branch");
-        args.push_back(version);
-        args.push_back(source);
-        args.push_back(dep_path.string());
+        // If we have a hash, we clone and then checkout the hash.
+        // We can still try --depth 1 if we're lucky, but it's safer to clone and checkout.
+        // Actually, let's try to be efficient:
+        args = {"git", "clone", source, dep_path.string()};
+        if (catalyst::processExec(std::move(args)).value().get() != 0) {
+            catalyst::logger.log(LogLevel::ERROR, "Failed to clone dependency: {}", name);
+            return std::unexpected(std::format("Failed to clone dependency: {}", name));
+        }
+        
+        args = {"git", "-C", dep_path.string(), "checkout", hash};
+        if (catalyst::processExec(std::move(args)).value().get() != 0) {
+            catalyst::logger.log(LogLevel::ERROR, "Failed to checkout hash {} for dependency: {}", hash, name);
+            return std::unexpected(std::format("Failed to checkout hash {} for dependency: {}", hash, name));
+        }
     }
-    catalyst::logger.log(LogLevel::DEBUG, "Executing command: {}", command);
-    if (catalyst::processExec(std::move(args)).value().get() != 0) {
-        catalyst::logger.log(LogLevel::ERROR, "Failed to fetch dependency: {}", name);
-        return std::unexpected(std::format("Failed to fetch dependency: {}", name));
-    }
+    
     return {};
 }
 
@@ -117,6 +135,14 @@ fetchLocal(const std::string &name, const std::string &path, const std::vector<s
     return {};
 }
 
+struct LockedDep {
+    std::string hash;
+    std::string url;
+    std::string version;
+    std::string triplet;
+    std::string path;
+};
+
 } // namespace
 
 std::expected<void, std::string> action(const Parse &parse_args) {
@@ -128,6 +154,35 @@ std::expected<void, std::string> action(const Parse &parse_args) {
     if (auto res = hooks::preFetch(config); !res) {
         catalyst::logger.log(LogLevel::ERROR, "Pre-fetch hook failed: {}", res.error());
         return res;
+    }
+
+    // Load lockfile if it exists
+    std::unordered_map<std::string, LockedDep> lockfile_deps;
+    fs::path lockfile_path = "catalyst.lock";
+    if (parse_args.workspace) {
+        lockfile_path = parse_args.workspace->getRoot() / "catalyst.lock";
+    }
+
+    if (fs::exists(lockfile_path)) {
+        catalyst::logger.log(LogLevel::INFO, "Using lockfile at {}", lockfile_path.string());
+        try {
+            YAML::Node lock_node = YAML::LoadFile(lockfile_path.string());
+            if (lock_node["dependencies"] && lock_node["dependencies"].IsSequence()) {
+                for (const auto &dep : lock_node["dependencies"]) {
+                    if (dep["name"]) {
+                        LockedDep ld;
+                        if (dep["hash"]) ld.hash = dep["hash"].as<std::string>();
+                        if (dep["url"]) ld.url = dep["url"].as<std::string>();
+                        if (dep["version"]) ld.version = dep["version"].as<std::string>();
+                        if (dep["triplet"]) ld.triplet = dep["triplet"].as<std::string>();
+                        if (dep["path"]) ld.path = dep["path"].as<std::string>();
+                        lockfile_deps[dep["name"].as<std::string>()] = ld;
+                    }
+                }
+            }
+        } catch (const std::exception &e) {
+            catalyst::logger.log(LogLevel::WARN, "Failed to load lockfile: {}", e.what());
+        }
     }
 
     std::string build_dir = config.getString("manifest.dirs.build").value_or("build");
@@ -178,11 +233,30 @@ std::expected<void, std::string> action(const Parse &parse_args) {
             }
 
             catalyst::logger.log(LogLevel::DEBUG, "Fetching dependency '{}' from '{}'", name, source);
+            
+            // Check if locked
+            std::string locked_hash = "";
+            std::string locked_url = "";
+            std::string locked_version = "";
+            std::string locked_triplet = "";
+            std::string locked_path = "";
+            if (lockfile_deps.contains(name)) {
+                locked_hash = lockfile_deps[name].hash;
+                locked_url = lockfile_deps[name].url;
+                locked_version = lockfile_deps[name].version;
+                locked_triplet = lockfile_deps[name].triplet;
+                locked_path = lockfile_deps[name].path;
+                catalyst::logger.log(LogLevel::DEBUG, "Dependency '{}' is locked.", name);
+            }
+
             if (source == "vcpkg") {
-                if (!dep["version"]) {
+                auto version = !locked_version.empty() ? locked_version : (dep["version"] ? dep["version"].as<std::string>() : "");
+                auto triplet = !locked_triplet.empty() ? locked_triplet : (dep["triplet"] ? dep["triplet"].as<std::string>() : "");
+                
+                if (version.empty()) {
                     return std::unexpected(std::format("vcpkg dependency '{}' is missing version.", name));
                 }
-                if (!dep["triplet"]) {
+                if (triplet.empty()) {
                     return std::unexpected(std::format("vcpkg dependency '{}' is missing triplet.", name));
                 }
                 if (auto res = fetchVcpkg(name); !res)
@@ -191,10 +265,10 @@ std::expected<void, std::string> action(const Parse &parse_args) {
                 if (auto res = fetchSystem(name); !res)
                     return std::unexpected(res.error());
             } else if (source == "local") {
-                if (!dep["path"]) {
+                auto path = !locked_path.empty() ? locked_path : (dep["path"] ? dep["path"].as<std::string>() : "");
+                if (path.empty()) {
                     return std::unexpected(std::format("Local dependency '{}' is missing path.", name));
                 }
-                auto path = dep["path"].as<std::string>();
                 std::vector<std::string> profiles_vec;
                 if (dep["profiles"] && dep["profiles"].IsSequence()) {
                     profiles_vec = dep["profiles"].as<std::vector<std::string>>();
@@ -206,11 +280,9 @@ std::expected<void, std::string> action(const Parse &parse_args) {
                 if (fs::exists(dep_path)) {
                     std::println(std::cout, "Skipping fetch for existing git dependency: {}", name);
                 } else {
-                    if (!dep["version"] || !dep["version"].IsScalar()) {
-                        return std::unexpected(std::format("git dependency '{}' is missing version.", name));
-                    }
-                    auto version = dep["version"].as<std::string>();
-                    if (auto res = fetchGit(build_dir, name, source, version); !res)
+                    auto version = !locked_version.empty() ? locked_version : (dep["version"] ? dep["version"].as<std::string>() : "latest");
+                    std::string url = !locked_url.empty() ? locked_url : ((source == "git" && dep["url"]) ? dep["url"].as<std::string>() : source);
+                    if (auto res = fetchGit(build_dir, name, url, version, locked_hash); !res)
                         return std::unexpected(res.error());
                 }
             }

--- a/src/subcommands/fetch/action.cpp
+++ b/src/subcommands/fetch/action.cpp
@@ -7,13 +7,14 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <yaml-cpp/yaml.h>
 
 #include "catalyst/hooks.hpp"
-#include "catalyst/utils/log/log.hpp"
 #include "catalyst/process_exec.hpp"
 #include "catalyst/subcommands/fetch.hpp"
+#include "catalyst/utils/log/log.hpp"
 
 namespace catalyst::fetch {
 namespace fs = std::filesystem;
@@ -43,14 +44,15 @@ std::expected<void, std::string> fetchVcpkg(const std::string &name) {
     return {};
 }
 
-std::expected<void, std::string>
-fetchGit(std::string build_dir, std::string name, std::string source, std::string version, std::string hash = "") {
-    catalyst::logger.log(LogLevel::DEBUG, "Fetching git dependency: {}@{} (hash: {}) from {}", name, version, hash, source);
+std::expected<void, std::string> fetchGit(
+    const std::string &build_dir, std::string name, std::string source, std::string version, std::string hash = "") {
+    catalyst::logger.log(
+        LogLevel::DEBUG, "Fetching git dependency: {}@{} (hash: {}) from {}", name, version, hash, source);
     fs::path dep_path = fs::path(build_dir) / "catalyst-libs" / name;
-    
+
     std::string target = hash.empty() ? version : hash;
     std::println(std::cout, "Fetching: {}@{} from {}", name, target, source);
-    
+
     std::vector<std::string> args;
     if (hash.empty()) {
         args = {"git", "clone", "--depth", "1"};
@@ -58,7 +60,7 @@ fetchGit(std::string build_dir, std::string name, std::string source, std::strin
             args.push_back(source);
             args.push_back(dep_path.string());
         } else {
-            args.push_back("--branch");
+            args.emplace_back("--branch");
             args.push_back(version);
             args.push_back(source);
             args.push_back(dep_path.string());
@@ -76,14 +78,14 @@ fetchGit(std::string build_dir, std::string name, std::string source, std::strin
             catalyst::logger.log(LogLevel::ERROR, "Failed to clone dependency: {}", name);
             return std::unexpected(std::format("Failed to clone dependency: {}", name));
         }
-        
+
         args = {"git", "-C", dep_path.string(), "checkout", hash};
         if (catalyst::processExec(std::move(args)).value().get() != 0) {
             catalyst::logger.log(LogLevel::ERROR, "Failed to checkout hash {} for dependency: {}", hash, name);
             return std::unexpected(std::format("Failed to checkout hash {} for dependency: {}", hash, name));
         }
     }
-    
+
     return {};
 }
 
@@ -93,8 +95,16 @@ std::expected<void, std::string> fetchSystem(const std::string &name) {
     return {};
 }
 
-std::expected<void, std::string>
-fetchLocal(const std::string &name, const std::string &path, const std::vector<std::string> &profiles) {
+struct FetchLocalArgs {
+    std::string name;
+    std::string path;
+    std::vector<std::string> profiles;
+};
+
+std::expected<void, std::string> fetchLocal(const FetchLocalArgs &fn_args) {
+    const std::string &name = fn_args.name;
+    const std::string &path = fn_args.path;
+    const std::vector<std::string> &profiles = fn_args.profiles;
     fs::path local_path = fs::absolute(path);
     std::string visited_env = std::getenv("CATALYST_VISITED") ? std::getenv("CATALYST_VISITED") : "";
 
@@ -114,7 +124,7 @@ fetchLocal(const std::string &name, const std::string &path, const std::vector<s
 
     std::vector<std::string> args = {"catalyst", "build"};
     if (profiles.size() != 0) {
-        args.push_back("--profiles");
+        args.emplace_back("--profiles");
         for (const auto &p : profiles) {
             args.push_back(p);
         }
@@ -171,11 +181,16 @@ std::expected<void, std::string> action(const Parse &parse_args) {
                 for (const auto &dep : lock_node["dependencies"]) {
                     if (dep["name"]) {
                         LockedDep ld;
-                        if (dep["hash"]) ld.hash = dep["hash"].as<std::string>();
-                        if (dep["url"]) ld.url = dep["url"].as<std::string>();
-                        if (dep["version"]) ld.version = dep["version"].as<std::string>();
-                        if (dep["triplet"]) ld.triplet = dep["triplet"].as<std::string>();
-                        if (dep["path"]) ld.path = dep["path"].as<std::string>();
+                        if (dep["hash"])
+                            ld.hash = dep["hash"].as<std::string>();
+                        if (dep["url"])
+                            ld.url = dep["url"].as<std::string>();
+                        if (dep["version"])
+                            ld.version = dep["version"].as<std::string>();
+                        if (dep["triplet"])
+                            ld.triplet = dep["triplet"].as<std::string>();
+                        if (dep["path"])
+                            ld.path = dep["path"].as<std::string>();
                         lockfile_deps[dep["name"].as<std::string>()] = ld;
                     }
                 }
@@ -233,13 +248,13 @@ std::expected<void, std::string> action(const Parse &parse_args) {
             }
 
             catalyst::logger.log(LogLevel::DEBUG, "Fetching dependency '{}' from '{}'", name, source);
-            
+
             // Check if locked
-            std::string locked_hash = "";
-            std::string locked_url = "";
-            std::string locked_version = "";
-            std::string locked_triplet = "";
-            std::string locked_path = "";
+            std::string locked_hash;
+            std::string locked_url;
+            std::string locked_version;
+            std::string locked_triplet;
+            std::string locked_path;
             if (lockfile_deps.contains(name)) {
                 locked_hash = lockfile_deps[name].hash;
                 locked_url = lockfile_deps[name].url;
@@ -250,38 +265,64 @@ std::expected<void, std::string> action(const Parse &parse_args) {
             }
 
             if (source == "vcpkg") {
-                auto version = !locked_version.empty() ? locked_version : (dep["version"] ? dep["version"].as<std::string>() : "");
-                auto triplet = !locked_triplet.empty() ? locked_triplet : (dep["triplet"] ? dep["triplet"].as<std::string>() : "");
-                
-                if (version.empty()) {
+                std::string version;
+                if (!locked_version.empty())
+                    version = locked_version;
+                else if (dep["version"])
+                    version = dep["version"].as<std::string>();
+                else
                     return std::unexpected(std::format("vcpkg dependency '{}' is missing version.", name));
-                }
-                if (triplet.empty()) {
+
+                std::string triplet;
+                if (!locked_triplet.empty())
+                    triplet = locked_triplet;
+                else if (dep["triplet"])
+                    triplet = dep["triplet"].as<std::string>();
+                else
                     return std::unexpected(std::format("vcpkg dependency '{}' is missing triplet.", name));
-                }
+
                 if (auto res = fetchVcpkg(name); !res)
                     return std::unexpected(res.error());
+
             } else if (source == "system") {
                 if (auto res = fetchSystem(name); !res)
                     return std::unexpected(res.error());
             } else if (source == "local") {
-                auto path = !locked_path.empty() ? locked_path : (dep["path"] ? dep["path"].as<std::string>() : "");
-                if (path.empty()) {
+                std::string path;
+                if (!locked_path.empty())
+                    path = locked_path;
+                else if (dep["path"])
+                    path = dep["path"].as<std::string>();
+                else
                     return std::unexpected(std::format("Local dependency '{}' is missing path.", name));
-                }
+
                 std::vector<std::string> profiles_vec;
                 if (dep["profiles"] && dep["profiles"].IsSequence()) {
                     profiles_vec = dep["profiles"].as<std::vector<std::string>>();
                 }
-                if (auto res = fetchLocal(name, path, profiles_vec); !res)
+                if (auto res = fetchLocal({.name = name, .path = path, .profiles = profiles_vec}); !res)
                     return std::unexpected(res.error());
             } else {
                 fs::path dep_path = fs::path(build_dir) / "catalyst-libs" / name;
                 if (fs::exists(dep_path)) {
                     std::println(std::cout, "Skipping fetch for existing git dependency: {}", name);
                 } else {
-                    auto version = !locked_version.empty() ? locked_version : (dep["version"] ? dep["version"].as<std::string>() : "latest");
-                    std::string url = !locked_url.empty() ? locked_url : ((source == "git" && dep["url"]) ? dep["url"].as<std::string>() : source);
+                    std::string version;
+                    if (!locked_version.empty())
+                        version = locked_version;
+                    else if (dep["version"])
+                        version = dep["version"].as<std::string>();
+                    else
+                        version = "latest";
+
+                    std::string url;
+                    if (!locked_url.empty())
+                        url = locked_url;
+                    else if (source == "git" && dep["url"])
+                        url = dep["url"].as<std::string>();
+                    else
+                        url = source;
+
                     if (auto res = fetchGit(build_dir, name, url, version, locked_hash); !res)
                         return std::unexpected(res.error());
                 }

--- a/src/subcommands/fetch/parse_cli.cpp
+++ b/src/subcommands/fetch/parse_cli.cpp
@@ -6,7 +6,7 @@ namespace catalyst::fetch {
 std::pair<CLI::App *, std::unique_ptr<Parse>> parse(CLI::App &app) {
     CLI::App *fetch = app.add_subcommand("fetch", "Fetch all dependencies for a profile composition.");
     auto ret = std::make_unique<Parse>();
-    fetch->add_option("--profiles", ret->profiles);
+    fetch->add_option("-p,--profiles", ret->profiles);
     return {fetch, std::move(ret)};
 }
 }; // namespace catalyst::fetch

--- a/src/subcommands/lock/action.cpp
+++ b/src/subcommands/lock/action.cpp
@@ -22,7 +22,7 @@ namespace {
 
 std::expected<std::string, std::string> resolveGitHash(const std::string &url, const std::string &version) {
     catalyst::logger.log(LogLevel::DEBUG, "Resolving git hash for {}@{}", url, version);
-    
+
     std::string ref = version;
     if (version == "latest") {
         ref = "HEAD";
@@ -53,7 +53,8 @@ std::expected<std::string, std::string> resolveGitHash(const std::string &url, c
     if (tab_pos == std::string::npos) {
         size_t space_pos = output.find(' ');
         if (space_pos == std::string::npos) {
-            return output.substr(0, 40); // Best effort
+            constexpr int BEST_EFFORT_LEN = 40;
+            return output.substr(0, BEST_EFFORT_LEN); // Best effort
         }
         return output.substr(0, space_pos);
     }
@@ -74,7 +75,7 @@ struct DependencyInfo {
     }
 };
 
-void collectDependencies(const utils::yaml::Configuration &config, 
+void collectDependencies(const utils::yaml::Configuration &config,
                          std::unordered_map<std::string, DependencyInfo> &locked_deps,
                          const std::optional<Workspace> &workspace) {
     if (auto deps = config.getRoot()["dependencies"]; deps && deps.IsSequence()) {
@@ -82,7 +83,7 @@ void collectDependencies(const utils::yaml::Configuration &config,
             if (!dep["name"] || !dep["source"]) continue;
 
             auto name = dep["name"].as<std::string>();
-            
+
             // Skip if it's a workspace member
             if (workspace && workspace->findPackage(name)) {
                 catalyst::logger.log(LogLevel::DEBUG, "Skipping workspace dependency: {}", name);
@@ -92,7 +93,7 @@ void collectDependencies(const utils::yaml::Configuration &config,
             DependencyInfo info;
             info.name = name;
             info.source = dep["source"].as<std::string>();
-            
+
             if (info.source == "git") {
                 info.url = dep["url"] ? dep["url"].as<std::string>() : dep["source"].as<std::string>();
                 info.version = dep["version"] ? dep["version"].as<std::string>() : "latest";
@@ -112,18 +113,18 @@ void collectDependencies(const utils::yaml::Configuration &config,
 
 std::expected<void, std::string> action(const Parse &parse_args) {
     catalyst::logger.log(LogLevel::DEBUG, "Lock subcommand invoked.");
-    
+
     std::unordered_map<std::string, DependencyInfo> locked_deps;
     fs::path lockfile_path = "catalyst.lock";
 
     if (parse_args.workspace) {
         catalyst::logger.log(LogLevel::INFO, "Resolving dependencies for workspace...");
         lockfile_path = parse_args.workspace->getRoot() / "catalyst.lock";
-        
+
         for (const auto &[name, member] : parse_args.workspace->getMembers()) {
             std::vector<std::string> profiles = member.profiles;
             if (profiles.empty()) profiles = {"common"};
-            
+
             try {
                 utils::yaml::Configuration config(profiles, member.path);
                 collectDependencies(config, locked_deps, parse_args.workspace);
@@ -140,7 +141,7 @@ std::expected<void, std::string> action(const Parse &parse_args) {
 
     YAML::Node lock_node;
     lock_node["lockfile_version"] = "1.0.0";
-    
+
     for (auto &[name, info] : locked_deps) {
         if (info.source == "git") {
             std::println(std::cout, "Resolving {}...", name);
@@ -160,7 +161,7 @@ std::expected<void, std::string> action(const Parse &parse_args) {
         if (!info.hash.empty()) dep_node["hash"] = info.hash;
         if (!info.triplet.empty()) dep_node["triplet"] = info.triplet;
         if (!info.path.empty()) dep_node["path"] = info.path;
-        
+
         lock_node["dependencies"].push_back(dep_node);
     }
 
@@ -169,7 +170,7 @@ std::expected<void, std::string> action(const Parse &parse_args) {
         return std::unexpected(std::format("Failed to open {} for writing.", lockfile_path.string()));
     }
     fout << lock_node;
-    
+
     std::println(std::cout, "Generated lockfile at {}", lockfile_path.string());
     return {};
 }

--- a/src/subcommands/lock/action.cpp
+++ b/src/subcommands/lock/action.cpp
@@ -1,0 +1,177 @@
+#include "catalyst/subcommands/lock.hpp"
+
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <iostream>
+#include <print>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <yaml-cpp/yaml.h>
+
+#include "catalyst/process_exec.hpp"
+#include "catalyst/utils/log/log.hpp"
+#include "catalyst/utils/yaml/configuration.hpp"
+
+namespace catalyst::lock {
+namespace fs = std::filesystem;
+
+namespace {
+
+std::expected<std::string, std::string> resolveGitHash(const std::string &url, const std::string &version) {
+    catalyst::logger.log(LogLevel::DEBUG, "Resolving git hash for {}@{}", url, version);
+    
+    std::string ref = version;
+    if (version == "latest") {
+        ref = "HEAD";
+    }
+
+    auto res = catalyst::processExecStdout({"git", "ls-remote", url, ref});
+    if (!res) {
+        return std::unexpected(std::format("Failed to resolve git hash for {}: {}", url, res.error()));
+    }
+
+    std::string output = res.value();
+    if (output.empty()) {
+        // Try as a tag/branch ref if HEAD didn't work or if it's a specific version
+        res = catalyst::processExecStdout({"git", "ls-remote", url, "refs/tags/" + ref});
+        if (res && !res.value().empty()) output = res.value();
+        else {
+            res = catalyst::processExecStdout({"git", "ls-remote", url, "refs/heads/" + ref});
+            if (res && !res.value().empty()) output = res.value();
+        }
+    }
+
+    if (output.empty()) {
+        return std::unexpected(std::format("No remote ref found for {} at {}", url, version));
+    }
+
+    // Output is usually "<hash>\t<ref>\n"
+    size_t tab_pos = output.find('\t');
+    if (tab_pos == std::string::npos) {
+        size_t space_pos = output.find(' ');
+        if (space_pos == std::string::npos) {
+            return output.substr(0, 40); // Best effort
+        }
+        return output.substr(0, space_pos);
+    }
+    return output.substr(0, tab_pos);
+}
+
+struct DependencyInfo {
+    std::string name;
+    std::string source;
+    std::string url;
+    std::string version;
+    std::string hash;
+    std::string triplet;
+    std::string path;
+
+    bool operator==(const DependencyInfo &other) const {
+        return name == other.name;
+    }
+};
+
+void collectDependencies(const utils::yaml::Configuration &config, 
+                         std::unordered_map<std::string, DependencyInfo> &locked_deps,
+                         const std::optional<Workspace> &workspace) {
+    if (auto deps = config.getRoot()["dependencies"]; deps && deps.IsSequence()) {
+        for (const auto &dep : deps) {
+            if (!dep["name"] || !dep["source"]) continue;
+
+            auto name = dep["name"].as<std::string>();
+            
+            // Skip if it's a workspace member
+            if (workspace && workspace->findPackage(name)) {
+                catalyst::logger.log(LogLevel::DEBUG, "Skipping workspace dependency: {}", name);
+                continue;
+            }
+
+            DependencyInfo info;
+            info.name = name;
+            info.source = dep["source"].as<std::string>();
+            
+            if (info.source == "git") {
+                info.url = dep["url"] ? dep["url"].as<std::string>() : dep["source"].as<std::string>();
+                info.version = dep["version"] ? dep["version"].as<std::string>() : "latest";
+            } else if (info.source == "vcpkg") {
+                info.version = dep["version"] ? dep["version"].as<std::string>() : "";
+                info.triplet = dep["triplet"] ? dep["triplet"].as<std::string>() : "";
+            } else if (info.source == "local") {
+                info.path = dep["path"] ? dep["path"].as<std::string>() : "";
+            }
+
+            locked_deps[name] = info;
+        }
+    }
+}
+
+} // namespace
+
+std::expected<void, std::string> action(const Parse &parse_args) {
+    catalyst::logger.log(LogLevel::DEBUG, "Lock subcommand invoked.");
+    
+    std::unordered_map<std::string, DependencyInfo> locked_deps;
+    fs::path lockfile_path = "catalyst.lock";
+
+    if (parse_args.workspace) {
+        catalyst::logger.log(LogLevel::INFO, "Resolving dependencies for workspace...");
+        lockfile_path = parse_args.workspace->getRoot() / "catalyst.lock";
+        
+        for (const auto &[name, member] : parse_args.workspace->getMembers()) {
+            std::vector<std::string> profiles = member.profiles;
+            if (profiles.empty()) profiles = {"common"};
+            
+            try {
+                utils::yaml::Configuration config(profiles, member.path);
+                collectDependencies(config, locked_deps, parse_args.workspace);
+            } catch (const std::exception &e) {
+                catalyst::logger.log(LogLevel::WARN, "Failed to load configuration for member {}: {}", name, e.what());
+            }
+        }
+    } else {
+        utils::yaml::Configuration config(parse_args.profiles);
+        collectDependencies(config, locked_deps, std::nullopt);
+    }
+
+    std::println(std::cout, "Locking {} dependencies...", locked_deps.size());
+
+    YAML::Node lock_node;
+    lock_node["lockfile_version"] = "1.0.0";
+    
+    for (auto &[name, info] : locked_deps) {
+        if (info.source == "git") {
+            std::println(std::cout, "Resolving {}...", name);
+            auto hash_res = resolveGitHash(info.url, info.version);
+            if (!hash_res) {
+                return std::unexpected(hash_res.error());
+            }
+            info.hash = hash_res.value();
+            catalyst::logger.log(LogLevel::INFO, "Resolved {} to {}", name, info.hash);
+        }
+
+        YAML::Node dep_node;
+        dep_node["name"] = info.name;
+        dep_node["source"] = info.source;
+        if (!info.url.empty()) dep_node["url"] = info.url;
+        if (!info.version.empty()) dep_node["version"] = info.version;
+        if (!info.hash.empty()) dep_node["hash"] = info.hash;
+        if (!info.triplet.empty()) dep_node["triplet"] = info.triplet;
+        if (!info.path.empty()) dep_node["path"] = info.path;
+        
+        lock_node["dependencies"].push_back(dep_node);
+    }
+
+    std::ofstream fout(lockfile_path);
+    if (!fout.is_open()) {
+        return std::unexpected(std::format("Failed to open {} for writing.", lockfile_path.string()));
+    }
+    fout << lock_node;
+    
+    std::println(std::cout, "Generated lockfile at {}", lockfile_path.string());
+    return {};
+}
+
+} // namespace catalyst::lock

--- a/src/subcommands/lock/parse_cli.cpp
+++ b/src/subcommands/lock/parse_cli.cpp
@@ -1,0 +1,15 @@
+#include "catalyst/subcommands/lock.hpp"
+
+#include <vector>
+
+#include <CLI/App.hpp>
+
+namespace catalyst::lock {
+std::pair<CLI::App *, std::unique_ptr<Parse>> parse(CLI::App &app) {
+    CLI::App *lock = app.add_subcommand("lock", "Resolve and pin dependencies to a catalyst.lock file.");
+    auto ret = std::make_unique<Parse>();
+    lock->add_option("-p,--profiles", ret->profiles, "Profile composition to use for dependency resolution.")
+        ->default_val(std::vector<std::string>{"common"});
+    return {lock, std::move(ret)};
+}
+} // namespace catalyst::lock


### PR DESCRIPTION
## Objective
Implement a 'lock' subcommand to resolve and pin dependency versions/hashes into a 'catalyst.lock' file, and update the 'fetch' command to use this lockfile.

## Key Changes
- **New Subcommand:** Added 'catalyst lock' to resolve and pin dependencies.
- **Lockfile Format:** YAML-based 'catalyst.lock' stores pinned hashes and metadata.
- **Workspace Support:** Consolidated lockfile logic at the workspace root.
- **Fetch Integration:** 'fetch' now prioritizes the lockfile for reproducible builds.
- **Documentation:** Added CLI reference for 'lock' and updated dependency/workspace concepts.

## Verification
- Verified 'catalyst lock' resolves git hashes.
- Confirmed 'catalyst fetch' uses pinned hashes from the lockfile.
- Validated workspace root lockfile generation.