### PR TITLE
fix: performance optimization

### DIFF
--- a/include/catalyst/utils/log/log.hpp
+++ b/include/catalyst/utils/log/log.hpp
@@ -72,8 +72,7 @@ private:
     generateJsonLogEvent(const std::chrono::system_clock::time_point &now, LogLevel level, const std::string &message);
 
     mutable std::ofstream log_file;
-    mutable std::mutex log_file_mutex;
-    mutable std::mutex stdio_mutex;
+    mutable std::mutex logging_mt;
     mutable bool verbose_logging = false;
 };
 

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -74,6 +74,7 @@ std::expected<void, std::string> executeCatalystHook(const YAML::Node &item, con
         }
 
         std::string joined;
+        joined.reserve(128);
         for (const auto &a : args)
             joined += a + " ";
         catalyst::logger.debug("[Catalyst Hook: {}] Running catalyst: {}", hook_name, joined);
@@ -125,15 +126,19 @@ std::expected<void, std::string> executeCodegenHook(const YAML::Node &codegen_no
         }
     };
 
-    for (size_t i = 0; i < inputs.size(); ++i)
-        replace_all(cmd, std::format("$IN[{}]", i), inputs[i]);
-    for (size_t i = 0; i < outputs.size(); ++i)
-        replace_all(cmd, std::format("$OUT[{}]", i), outputs[i]);
+    if (cmd.contains("$IN[")) {
+        for (size_t i = 0; i < inputs.size(); ++i)
+            replace_all(cmd, "$IN[" + std::to_string(i) + "]", inputs[i]);
+    }
+    if (cmd.contains("$OUT[")) {
+        for (size_t i = 0; i < outputs.size(); ++i)
+            replace_all(cmd, "$OUT[" + std::to_string(i) + "]", outputs[i]);
+    }
 
-    if (cmd.find("$IN[") != std::string::npos) {
+    if (cmd.contains("$IN[")) {
         return std::unexpected(std::format("Hook '{}' codegen cmd references out-of-bounds $IN index", hook_name));
     }
-    if (cmd.find("$OUT[") != std::string::npos) {
+    if (cmd.contains("$OUT[")) {
         return std::unexpected(std::format("Hook '{}' codegen cmd references out-of-bounds $OUT index", hook_name));
     }
 

--- a/src/subcommands/bench/action.cpp
+++ b/src/subcommands/bench/action.cpp
@@ -122,12 +122,14 @@ std::expected<void, std::string> action(const Parse &args) {
     if (!lib_path_res) {
         return std::unexpected("Failed to generate LD_LIBRARY_PATH");
     }
+
+    std::unordered_map<std::string, std::string> exec_env;
 #if defined(_WIN32)
-    _putenv_s("PATH", lib_path_res.value().c_str());
+    exec_env["PATH"] = lib_path_res.value();
 #elif defined(__APPLE__)
-    setenv("DYLD_LIBRARY_PATH", lib_path_res.value().c_str(), 1);
+    exec_env["DYLD_LIBRARY_PATH"] = lib_path_res.value();
 #else
-    setenv("LD_LIBRARY_PATH", lib_path_res.value().c_str(), 1);
+    exec_env["LD_LIBRARY_PATH"] = lib_path_res.value();
 #endif
 
     catalyst::logger.debug("Executing command: {}", command);
@@ -136,7 +138,7 @@ std::expected<void, std::string> action(const Parse &args) {
     exec_args.push_back(exe_path.string());
     exec_args.insert(exec_args.end(), args.params.begin(), args.params.end());
 
-    if (int res = catalyst::processExec(std::move(exec_args)).value().get(); res) {
+    if (int res = catalyst::processExec(std::move(exec_args), std::nullopt, exec_env).value().get(); res) {
         return std::unexpected(
             std::format("Target executable: {} exited with failure code: {}", exe_path.string(), res));
     }

--- a/src/subcommands/clean/action.cpp
+++ b/src/subcommands/clean/action.cpp
@@ -5,6 +5,7 @@
 
 #include <catalyst/hooks.hpp>
 #include <catalyst/subcommands/clean.hpp>
+#include "catalyst/dir_guard.hpp"
 #include <yaml-cpp/node/node.h>
 
 #include "catalyst/process_exec.hpp"
@@ -19,10 +20,9 @@ std::expected<void, std::string> action(const Parse &parse_args) {
     catalyst::logger.debug("Clean subcommand invoked.");
 
     if (parse_args.workspace) {
-        fs::path current = fs::current_path();
         bool is_root = false;
         try {
-            is_root = fs::equivalent(parse_args.workspace->getRoot(), current);
+            is_root = fs::equivalent(parse_args.workspace->getRoot(), fs::current_path());
         } catch (...) {
             std::ignore;
         }
@@ -33,7 +33,7 @@ std::expected<void, std::string> action(const Parse &parse_args) {
 
             for (const auto &[name, member] : parse_args.workspace->getMembers()) {
                 catalyst::logger.info("Cleaning member: {}", name);
-                fs::current_path(member.path);
+                catalyst::DirectoryChangeGuard dir_guard(member.path);
 
                 Parse member_args = parse_args;
                 member_args.workspace = std::nullopt; // Prevent recursion loop
@@ -42,7 +42,6 @@ std::expected<void, std::string> action(const Parse &parse_args) {
                     catalyst::logger.error("Clean failed for member: {}", name);
                     any_failed = true;
                 }
-                fs::current_path(current);
             }
             if (any_failed)
                 return std::unexpected("Clean failed for some members.");

--- a/src/subcommands/download/action.cpp
+++ b/src/subcommands/download/action.cpp
@@ -17,19 +17,17 @@ namespace catalyst::download {
 
 namespace {
 std::string randomString(size_t length) {
-    auto randchar = []() -> char {
-        static std::random_device rd;
-        static std::mt19937 rng(rd());
+    std::random_device rd;
+    std::mt19937 rng(rd());
 
-        constexpr std::array<char, 63> CHARSET = {"0123456789"
-                                                  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                  "abcdefghijklmnopqrstuvwxyz"};
-        const size_t max_index = CHARSET.size() - 1;
-        static std::uniform_int_distribution<size_t> dist(0, max_index - 1);
-        return CHARSET.at(dist(rng));
-    };
-    std::string str(length, 0);
-    std::generate_n(str.begin(), length, randchar);
+    constexpr std::string_view CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    const size_t max_index = CHARSET.size() - 1;
+    std::uniform_int_distribution<size_t> dist(0, max_index);
+
+    std::string str(length, '\0');
+    for (size_t i = 0; i < length; ++i) {
+        str[i] = CHARSET[dist(rng)];
+    }
     return str;
 }
 } // namespace

--- a/src/subcommands/fetch/action.cpp
+++ b/src/subcommands/fetch/action.cpp
@@ -2,11 +2,13 @@
 #include <expected>
 #include <filesystem>
 #include <format>
+#include <future>
 #include <iostream>
 #include <print>
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <yaml-cpp/yaml.h>
@@ -99,19 +101,28 @@ std::expected<void, std::string> fetchLocal(const FetchLocalArgs &fn_args) {
     const std::string &name = fn_args.name;
     const std::string &path = fn_args.path;
     const std::vector<std::string> &profiles = fn_args.profiles;
-    fs::path local_path = fs::absolute(path);
-    std::string visited_env = std::getenv("CATALYST_VISITED") ? std::getenv("CATALYST_VISITED") : "";
+    fs::path local_path = fs::weakly_canonical(path);
+    std::string local_path_str = local_path.string();
+    const char* visited_env_tmp = std::getenv("CATALYST_VISITED");
+    std::string visited_env = visited_env_tmp ? visited_env_tmp : "";
 
     // Cycle detection
-    std::stringstream ss(visited_env);
-    std::string segment;
-    while (std::getline(ss, segment, ':')) {
-        if (!segment.empty() && fs::equivalent(fs::path(segment), local_path)) {
-            return std::unexpected(std::format("Dependency cycle detected involving {}", local_path.string()));
+    std::string_view visited_view(visited_env);
+    size_t start = 0;
+    while (start < visited_view.length()) {
+        size_t end = visited_view.find(':', start);
+        if (end == std::string_view::npos) end = visited_view.length();
+        std::string_view segment = visited_view.substr(start, end - start);
+        if (!segment.empty()) {
+            std::error_code ec;
+            if (fs::equivalent(fs::path(segment), local_path, ec) || (!ec && segment == local_path_str)) {
+                return std::unexpected(std::format("Dependency cycle detected involving {}", local_path_str));
+            }
         }
+        start = end + 1;
     }
 
-    std::string new_visited = visited_env.empty() ? local_path.string() : visited_env + ":" + local_path.string();
+    std::string new_visited = visited_env.empty() ? local_path_str : visited_env + ":" + local_path_str;
 
     catalyst::logger.debug("Recursively building local dependency: {} at {}", name, local_path.string());
     std::println(std::cout, "Building local dependency: {} at {}", name, local_path.string());
@@ -149,6 +160,125 @@ struct LockedDep {
     std::string triplet;
     std::string path;
 };
+
+std::expected<void, std::string> fetchDependency(
+    const YAML::Node &dep,
+    const std::string &build_dir,
+    const std::unordered_map<std::string, LockedDep> &lockfile_deps,
+    const Parse &parse_args) {
+
+    auto name = dep["name"].as<std::string>();
+    auto source = dep["source"].as<std::string>();
+
+    if (parse_args.workspace) {
+        if (auto member = parse_args.workspace->findPackage(name)) {
+            catalyst::logger.info("Dependency '{}' found in workspace at '{}'. Linking...", name, member->path.string());
+            fs::path lib_path = fs::path(build_dir) / "catalyst-libs" / name;
+
+            try {
+                if (fs::exists(lib_path) || fs::is_symlink(lib_path)) {
+                    if (fs::is_symlink(lib_path)) {
+                        if (fs::read_symlink(lib_path) != member->path) {
+                            fs::remove(lib_path);
+                            fs::create_directory_symlink(member->path, lib_path);
+                        }
+                    } else {
+                        fs::remove_all(lib_path);
+                        fs::create_directory_symlink(member->path, lib_path);
+                    }
+                } else {
+                    fs::create_directories(lib_path.parent_path());
+                    fs::create_directory_symlink(member->path, lib_path);
+                }
+            } catch (const std::exception &e) {
+                return std::unexpected(e.what());
+            }
+            return {};
+        }
+    }
+
+    catalyst::logger.debug("Fetching dependency '{}' from '{}'", name, source);
+
+    // Check if locked
+    std::string locked_hash;
+    std::string locked_url;
+    std::string locked_version;
+    std::string locked_triplet;
+    std::string locked_path;
+    if (lockfile_deps.contains(name)) {
+        locked_hash = lockfile_deps.at(name).hash;
+        locked_url = lockfile_deps.at(name).url;
+        locked_version = lockfile_deps.at(name).version;
+        locked_triplet = lockfile_deps.at(name).triplet;
+        locked_path = lockfile_deps.at(name).path;
+        catalyst::logger.debug("Dependency '{}' is locked.", name);
+    }
+
+    if (source == "vcpkg") {
+        std::string version;
+        if (!locked_version.empty())
+            version = locked_version;
+        else if (dep["version"])
+            version = dep["version"].as<std::string>();
+        else
+            return std::unexpected(std::format("vcpkg dependency '{}' is missing version.", name));
+
+        std::string triplet;
+        if (!locked_triplet.empty())
+            triplet = locked_triplet;
+        else if (dep["triplet"])
+            triplet = dep["triplet"].as<std::string>();
+        else
+            return std::unexpected(std::format("vcpkg dependency '{}' is missing triplet.", name));
+
+        if (auto res = fetchVcpkg(name); !res)
+            return std::unexpected(res.error());
+
+    } else if (source == "system") {
+        if (auto res = fetchSystem(name); !res)
+            return std::unexpected(res.error());
+    } else if (source == "local") {
+        std::string path;
+        if (!locked_path.empty())
+            path = locked_path;
+        else if (dep["path"])
+            path = dep["path"].as<std::string>();
+        else
+            return std::unexpected(std::format("Local dependency '{}' is missing path.", name));
+
+        std::vector<std::string> profiles_vec;
+        if (dep["profiles"] && dep["profiles"].IsSequence()) {
+            profiles_vec = dep["profiles"].as<std::vector<std::string>>();
+        }
+        if (auto res = fetchLocal({.name = name, .path = path, .profiles = profiles_vec}); !res)
+            return std::unexpected(res.error());
+    } else {
+        fs::path dep_path = fs::path(build_dir) / "catalyst-libs" / name;
+        if (fs::exists(dep_path)) {
+            std::println(std::cout, "Skipping fetch for existing git dependency: {}", name);
+        } else {
+            std::string version;
+            if (!locked_version.empty())
+                version = locked_version;
+            else if (dep["version"])
+                version = dep["version"].as<std::string>();
+            else
+                version = "latest";
+
+            std::string url;
+            if (!locked_url.empty())
+                url = locked_url;
+            else if (source == "git" && dep["url"])
+                url = dep["url"].as<std::string>();
+            else
+                url = source;
+
+            if (auto res = fetchGit(build_dir, name, url, version, locked_hash); !res)
+                return std::unexpected(res.error());
+        }
+    }
+    return {};
+}
 
 } // namespace
 
@@ -198,6 +328,10 @@ std::expected<void, std::string> action(const Parse &parse_args) {
 
     std::string build_dir = config.getBuildDir().string();
     if (auto deps = config.getRoot()["dependencies"]; deps && deps.IsSequence()) {
+        std::vector<YAML::Node> parallel_deps;
+        std::vector<YAML::Node> serial_deps;
+        std::unordered_set<std::string> seen_deps;
+
         for (int ii = 0; auto dep : deps) {
             if (!dep["name"]) {
                 return std::unexpected(std::format("Dependency: {} does not define field: name", ii));
@@ -207,118 +341,63 @@ std::expected<void, std::string> action(const Parse &parse_args) {
                 return std::unexpected(
                     std::format("Dependency: {} does not define field: source", dep["name"].as<std::string>()));
             }
-            auto name = dep["name"].as<std::string>();
-            auto source = dep["source"].as<std::string>();
 
-            if (parse_args.workspace) {
-                if (auto member = parse_args.workspace->findPackage(name)) {
-                    catalyst::logger.info(
-                        "Dependency '{}' found in workspace at '{}'. Linking...", name, member->path.string());
-                    fs::path lib_path = fs::path(build_dir) / "catalyst-libs" / name;
+            std::string name = dep["name"].as<std::string>();
 
-                    try {
-                        if (fs::exists(lib_path) || fs::is_symlink(lib_path)) {
-                            if (fs::is_symlink(lib_path)) {
-                                if (fs::read_symlink(lib_path) != member->path) {
-                                    fs::remove(lib_path);
-                                    fs::create_directory_symlink(member->path, lib_path);
-                                }
-                            } else {
-                                fs::remove_all(lib_path);
-                                fs::create_directory_symlink(member->path, lib_path);
-                            }
-                        } else {
-                            fs::create_directories(lib_path.parent_path());
-                            fs::create_directory_symlink(member->path, lib_path);
-                        }
-                    } catch (const std::exception &e) {
-                        return std::unexpected(e.what());
-                    }
-                    continue;
-                }
+            // 1. Deduplicate by logical target name
+            if (seen_deps.contains(name)) {
+                catalyst::logger.debug("Skipping duplicate dependency entry: {}", name);
+                ++ii;
+                continue;
             }
+            seen_deps.insert(name);
 
-            catalyst::logger.debug("Fetching dependency '{}' from '{}'", name, source);
+            std::string source = dep["source"].as<std::string>();
+            bool is_workspace_member = parse_args.workspace && parse_args.workspace->findPackage(name).has_value();
 
-            // Check if locked
-            std::string locked_hash;
-            std::string locked_url;
-            std::string locked_version;
-            std::string locked_triplet;
-            std::string locked_path;
-            if (lockfile_deps.contains(name)) {
-                locked_hash = lockfile_deps[name].hash;
-                locked_url = lockfile_deps[name].url;
-                locked_version = lockfile_deps[name].version;
-                locked_triplet = lockfile_deps[name].triplet;
-                locked_path = lockfile_deps[name].path;
-                catalyst::logger.debug("Dependency '{}' is locked.", name);
-            }
-
-            if (source == "vcpkg") {
-                std::string version;
-                if (!locked_version.empty())
-                    version = locked_version;
-                else if (dep["version"])
-                    version = dep["version"].as<std::string>();
-                else
-                    return std::unexpected(std::format("vcpkg dependency '{}' is missing version.", name));
-
-                std::string triplet;
-                if (!locked_triplet.empty())
-                    triplet = locked_triplet;
-                else if (dep["triplet"])
-                    triplet = dep["triplet"].as<std::string>();
-                else
-                    return std::unexpected(std::format("vcpkg dependency '{}' is missing triplet.", name));
-
-                if (auto res = fetchVcpkg(name); !res)
-                    return std::unexpected(res.error());
-
-            } else if (source == "system") {
-                if (auto res = fetchSystem(name); !res)
-                    return std::unexpected(res.error());
-            } else if (source == "local") {
-                std::string path;
-                if (!locked_path.empty())
-                    path = locked_path;
-                else if (dep["path"])
-                    path = dep["path"].as<std::string>();
-                else
-                    return std::unexpected(std::format("Local dependency '{}' is missing path.", name));
-
-                std::vector<std::string> profiles_vec;
-                if (dep["profiles"] && dep["profiles"].IsSequence()) {
-                    profiles_vec = dep["profiles"].as<std::vector<std::string>>();
-                }
-                if (auto res = fetchLocal({.name = name, .path = path, .profiles = profiles_vec}); !res)
-                    return std::unexpected(res.error());
+            // 2. Categorize by safety
+            // Workspace links, vcpkg installs, and local builds mutate shared state
+            if (is_workspace_member || source == "vcpkg" || source == "local") {
+                serial_deps.push_back(dep);
             } else {
-                fs::path dep_path = fs::path(build_dir) / "catalyst-libs" / name;
-                if (fs::exists(dep_path)) {
-                    std::println(std::cout, "Skipping fetch for existing git dependency: {}", name);
-                } else {
-                    std::string version;
-                    if (!locked_version.empty())
-                        version = locked_version;
-                    else if (dep["version"])
-                        version = dep["version"].as<std::string>();
-                    else
-                        version = "latest";
-
-                    std::string url;
-                    if (!locked_url.empty())
-                        url = locked_url;
-                    else if (source == "git" && dep["url"])
-                        url = dep["url"].as<std::string>();
-                    else
-                        url = source;
-
-                    if (auto res = fetchGit(build_dir, name, url, version, locked_hash); !res)
-                        return std::unexpected(res.error());
-                }
+                parallel_deps.push_back(dep);
             }
             ++ii;
+        }
+
+        // 3. Execute parallel-safe (git, system)
+        if (!parallel_deps.empty()) {
+            std::vector<std::future<std::expected<void, std::string>>> futures;
+            for (auto dep : parallel_deps) {
+                // Launch fetch in parallel
+                futures.push_back(std::async(std::launch::async, [dep, build_dir, &lockfile_deps, &parse_args]() {
+                    return fetchDependency(dep, build_dir, lockfile_deps, parse_args);
+                }));
+            }
+
+            // Wait for all fetches and collect errors
+            std::vector<std::string> errors;
+            for (auto &f : futures) {
+                if (auto res = f.get(); !res) {
+                    errors.push_back(res.error());
+                }
+            }
+
+            if (!errors.empty()) {
+                std::string combined_error = "Parallel fetch failed with the following errors:\n";
+                for (const auto &err : errors) {
+                    combined_error += " - " + err + "\n";
+                }
+                return std::unexpected(combined_error);
+            }
+        }
+
+        // 4. Execute serial-only (vcpkg, local, workspace link)
+        // Maintain fail-fast semantics for these
+        for (auto dep : serial_deps) {
+            if (auto res = fetchDependency(dep, build_dir, lockfile_deps, parse_args); !res) {
+                return res; // Fail fast
+            }
         }
     }
 

--- a/src/subcommands/fmt/action.cpp
+++ b/src/subcommands/fmt/action.cpp
@@ -15,6 +15,10 @@
 #include "catalyst/subcommands/generate.hpp"
 #include "catalyst/utils/log/log.hpp"
 
+namespace {
+std::expected<void, std::string> execBatch(std::vector<std::basic_string<char>> args);
+}
+
 namespace catalyst::fmt {
 std::expected<void, std::string> action(const Parse &parse_args) {
     catalyst::logger.debug("Fmt subcommand invoked.");
@@ -65,30 +69,45 @@ std::expected<void, std::string> action(const Parse &parse_args) {
         }
     }
 
-    std::atomic<bool> formatting_error = false;
-    std::string error_message;
-    std::mutex error_mutex;
-
-    std::for_each(std::execution::par, files_to_format.begin(), files_to_format.end(), [&](const auto &file) -> void {
-        if (formatting_error) {
-            return;
-        }
-        catalyst::logger.debug("Formatting {}", file.string());
-        if (int res = catalyst::processExec({formatter, "-i", file.string()}).value().get(); res) {
-            std::lock_guard<std::mutex> lock(error_mutex);
-            if (!formatting_error) {
-                error_message = "Error running clang-format on " + file.string();
-                catalyst::logger.error("{}", error_message);
-                formatting_error = true;
-            }
-        }
-    });
-
-    if (formatting_error) {
-        return std::unexpected(error_message);
+    if (files_to_format.empty()) {
+        return {};
     }
+
+    constexpr size_t MAX_ARG_BYTES = 1 << (10 + 7); // 128 KiB limit
+    size_t current_bytes = formatter.size() + 3;    // formatter + " -i"
+    std::vector<std::string> args = {formatter, "-i"};
+
+    for (const fs::path &file_to_format : files_to_format) {
+        std::string file_str = file_to_format.string();
+        size_t entry_size = file_str.size() + 1; // +1 for separator/null
+
+        if (args.size() > 2 && current_bytes + entry_size > MAX_ARG_BYTES) {
+            if (auto res = execBatch(std::move(args)); !res)
+                return res;
+            args = {formatter, "-i"};
+            current_bytes = formatter.size() + 3;
+        }
+
+        args.push_back(std::move(file_str));
+        current_bytes += entry_size;
+    }
+
+    if (args.size() > 2)
+        if (auto res = execBatch(std::move(args)); !res)
+            return res;
 
     catalyst::logger.debug("Fmt subcommand finished successfully.");
     return {};
 }
 } // namespace catalyst::fmt
+
+namespace {
+std::expected<void, std::string> execBatch(std::vector<std::basic_string<char>> args) {
+    if (int res = catalyst::processExec(std::forward<decltype(args)>(args)).value().get(); res) {
+        std::string error_message = "Error running clang-format. Exit code: " + std::to_string(res);
+        catalyst::logger.error("{}", error_message);
+        return std::unexpected(error_message);
+    }
+    return {};
+}
+} // namespace

--- a/src/subcommands/generate/action.cpp
+++ b/src/subcommands/generate/action.cpp
@@ -24,7 +24,7 @@ namespace fs = std::filesystem;
 
 namespace {
 
-bool isEnabled(bool default_enabled, const std::string &feature, const std::vector<std::string> &enabled_features);
+bool isEnabled(bool default_enabled, const std::string &feature, const std::unordered_set<std::string> &enabled_features);
 
 void writeVariables(const catalyst::utils::yaml::Configuration &config,
                     catalyst::generate::buildwriters::BaseWriter &writer,
@@ -257,6 +257,7 @@ void writeVariables(const catalyst::utils::yaml::Configuration &config,
         logger.warn("VCPKG_ROOT environment variable is not defined.");
     }
 
+    std::unordered_set<std::string> enabled_features_set(enabled_features.begin(), enabled_features.end());
     if (const auto &features_node = config.getRoot()["features"]; features_node && features_node.IsMap()) {
         for (auto it = features_node.begin(); it != features_node.end(); ++it) {
             auto feature = it->first.as<std::string>();
@@ -270,7 +271,7 @@ void writeVariables(const catalyst::utils::yaml::Configuration &config,
             std::string flag = std::format(" -DFF_{}__{}={}",
                                            config.getString("manifest.name").value_or("name"),
                                            feature,
-                                           isEnabled(default_enabled, feature, enabled_features) ? "1" : "0");
+                                           isEnabled(default_enabled, feature, enabled_features_set) ? "1" : "0");
             cxxflags += flag;
             ccflags += flag;
         }
@@ -330,6 +331,7 @@ void writeRules(catalyst::generate::buildwriters::BaseWriter &writer) {
 void featureFilter(std::unordered_set<fs::path> &source_set,
                    const catalyst::utils::yaml::Configuration &config,
                    const std::vector<std::string> &enabled_features) {
+    std::unordered_set<std::string> enabled_features_set(enabled_features.begin(), enabled_features.end());
     std::unordered_set<std::string> inactive_features;
     if (const auto &features_node = config.getRoot()["features"]; features_node && features_node.IsMap()) {
         for (auto it = features_node.begin(); it != features_node.end(); ++it) {
@@ -341,7 +343,7 @@ void featureFilter(std::unordered_set<fs::path> &source_set,
                 default_enabled = it->second.as<bool>();
             }
 
-            if (!isEnabled(default_enabled, feature, enabled_features))
+            if (!isEnabled(default_enabled, feature, enabled_features_set))
                 inactive_features.insert(feature);
         }
     }
@@ -365,9 +367,9 @@ void featureFilter(std::unordered_set<fs::path> &source_set,
     }
 }
 
-bool isEnabled(bool default_enabled, const std::string &feature, const std::vector<std::string> &enabled_features) {
-    bool explicitly_enabled = std::ranges::find(enabled_features, feature) != enabled_features.end();
-    bool explicitly_disabled = std::ranges::find(enabled_features, "no-" + feature) != enabled_features.end();
+bool isEnabled(bool default_enabled, const std::string &feature, const std::unordered_set<std::string> &enabled_features) {
+    bool explicitly_enabled = enabled_features.contains(feature);
+    bool explicitly_disabled = enabled_features.contains("no-" + feature);
 
     bool is_enabled = default_enabled;
     if (explicitly_enabled) {

--- a/src/subcommands/install/action.cpp
+++ b/src/subcommands/install/action.cpp
@@ -134,16 +134,7 @@ std::expected<void, std::string> action(const Parse &parse_args) {
                     "Installing headers from: {} -> {}", source_inc.string(), dest_include_dir.string());
                 try {
                     fs::create_directories(dest_include_dir);
-                    for (const auto &entry : fs::recursive_directory_iterator(source_inc)) {
-                        fs::path relative_path = fs::relative(entry.path(), source_inc);
-                        fs::path target_path = dest_include_dir / relative_path;
-                        if (fs::is_directory(entry)) {
-                            fs::create_directories(target_path);
-                        } else {
-                            fs::create_directories(target_path.parent_path());
-                            fs::copy_file(entry.path(), target_path, fs::copy_options::overwrite_existing);
-                        }
-                    }
+                    fs::copy(source_inc, dest_include_dir, fs::copy_options::recursive | fs::copy_options::overwrite_existing);
                 } catch (const fs::filesystem_error &e) {
                     return std::unexpected(std::format("Failed to install headers: {}", e.what()));
                 }

--- a/src/subcommands/lock/action.cpp
+++ b/src/subcommands/lock/action.cpp
@@ -123,17 +123,39 @@ std::expected<void, std::string> action(const Parse &parse_args) {
         catalyst::logger.info("Resolving dependencies for workspace...");
         lockfile_path = parse_args.workspace->getRoot() / "catalyst.lock";
 
-        for (const auto &[name, member] : parse_args.workspace->getMembers()) {
-            std::vector<std::string> profiles = member.profiles;
-            if (profiles.empty())
-                profiles = {"common"};
+        // Load configurations in parallel, then collect dependencies sequentially
+        // for deterministic resolution order
+        const auto &members = parse_args.workspace->getMembers();
+        struct MemberConfig {
+            std::string name;
+            std::optional<utils::yaml::Configuration> config;
+        };
+        std::vector<MemberConfig> configs(members.size());
+        std::vector<std::thread> threads;
 
-            try {
-                utils::yaml::Configuration config(profiles, member.path);
-                collectDependencies(config, locked_deps, parse_args.workspace);
-            } catch (const std::exception &e) {
-                catalyst::logger.warn("Failed to load configuration for member {}: {}", name, e.what());
-            }
+        size_t idx = 0;
+        for (const auto &[name, member] : members) {
+            configs[idx].name = name;
+            threads.emplace_back([&cfg = configs[idx], m = member]() {
+                std::vector<std::string> profiles = m.profiles;
+                if (profiles.empty())
+                    profiles = {"common"};
+
+                try {
+                    cfg.config.emplace(profiles, m.path);
+                } catch (const std::exception &e) {
+                    catalyst::logger.warn("Failed to load configuration for member {}: {}", cfg.name, e.what());
+                }
+            });
+            ++idx;
+        }
+        for (auto &t : threads) {
+            t.join();
+        }
+
+        for (const auto &mc : configs) {
+            if (mc.config)
+                collectDependencies(*mc.config, locked_deps, parse_args.workspace);
         }
     } else {
         utils::yaml::Configuration config(parse_args.profiles);

--- a/src/subcommands/run/action.cpp
+++ b/src/subcommands/run/action.cpp
@@ -92,12 +92,14 @@ std::expected<void, std::string> action(const Parse &args) {
     if (!lib_path_res) {
         return std::unexpected("Failed to generate LD_LIBRARY_PATH");
     }
+
+    std::unordered_map<std::string, std::string> exec_env;
 #if defined(_WIN32)
-    _putenv_s("PATH", lib_path_res.value().c_str());
+    exec_env["PATH"] = lib_path_res.value();
 #elif defined(__APPLE__)
-    setenv("DYLD_LIBRARY_PATH", lib_path_res.value().c_str(), 1);
+    exec_env["DYLD_LIBRARY_PATH"] = lib_path_res.value();
 #else
-    setenv("LD_LIBRARY_PATH", lib_path_res.value().c_str(), 1);
+    exec_env["LD_LIBRARY_PATH"] = lib_path_res.value();
 #endif
 
     catalyst::logger.debug("Executing command: {}", command);
@@ -106,7 +108,7 @@ std::expected<void, std::string> action(const Parse &args) {
     exec_args.push_back(exe_path.string());
     exec_args.insert(exec_args.end(), args.params.begin(), args.params.end());
 
-    if (int res = catalyst::processExec(std::move(exec_args)).value().get(); res) {
+    if (int res = catalyst::processExec(std::move(exec_args), std::nullopt, exec_env).value().get(); res) {
         return std::unexpected(
             std::format("Target executable: {} exited with failure code: {}", exe_path.string(), res));
     }

--- a/src/subcommands/tidy/action.cpp
+++ b/src/subcommands/tidy/action.cpp
@@ -79,10 +79,9 @@ std::expected<void, std::string> action(const Parse &parse_args) {
                 }
                 linter_args.push_back(file_to_process.string());
                 if (int res = catalyst::processExec(std::move(linter_args)).value().get(); res != 0) {
-                    err_log_mt.lock();
+                    std::lock_guard<std::mutex> lock{err_log_mt};
                     catalyst::logger.error("Linter failed for {}: exit code {}", file_to_process.string(), res);
                     has_errors = true;
-                    err_log_mt.unlock();
                 }
             }
         });

--- a/src/utils/log/log.cpp
+++ b/src/utils/log/log.cpp
@@ -41,24 +41,24 @@ LogT::~LogT() {
 }
 
 bool LogT::isOpen() const {
-    std::lock_guard<std::mutex> lock(log_file_mutex);
+    std::lock_guard<std::mutex> lock(logging_mt);
     return log_file.is_open();
 }
 
 void LogT::flush() const {
-    std::lock_guard<std::mutex> lock(log_file_mutex);
+    std::lock_guard<std::mutex> lock(logging_mt);
     log_file.flush();
 }
 
 void LogT::close() const {
-    std::lock_guard<std::mutex> lock(log_file_mutex);
+    std::lock_guard<std::mutex> lock(logging_mt);
     if (log_file.is_open()) {
         log_file.close();
     }
 }
 
 void LogT::logImpl(LogLevel level, const std::string &message) const {
-    std::lock_guard<std::mutex> lock(log_file_mutex);
+    std::lock_guard<std::mutex> lock(logging_mt);
     if (!log_file.is_open()) {
         return;
     }
@@ -83,22 +83,18 @@ void LogT::logImpl(LogLevel level, const std::string &message) const {
                 break;
         }
 
-        if (level == LogLevel::ERROR) {
-            std::lock_guard<std::mutex> lock{stdio_mutex};
-            std::cerr << std::format("[{:%Y-%m-%d %H:%M:%S}] ", now) << color
-                      << std::format("[{}] {}", toString(level), message) << RESET << std::endl;
-        } else {
-            std::lock_guard<std::mutex> lock{stdio_mutex};
-            std::cout << std::format("[{:%Y-%m-%d %H:%M:%S}] ", now) << color
-                      << std::format("[{}] {}", toString(level), message) << RESET << std::endl;
-        }
+        std::ostream &sink = (level == LogLevel::ERROR) ? std::cerr : std::cout;
+        std::string time_str = std::format("{:%Y-%m-%d %H:%M:%S}", now);
+        std::string log_str = std::format("[{}] {}", toString(level), message);
+        sink << time_str << " " << color << log_str << RESET << '\n';
     }
 }
 
 std::string LogT::generateJsonLogEvent(const std::chrono::system_clock::time_point &now,
                                        LogLevel level,
                                        const std::string &message) {
-    nlohmann::json j;
+    static thread_local nlohmann::json j;
+    j.clear();
     j["timestamp"] = std::format("{:%Y-%m-%d %H:%M:%S}", now);
     j["level"] = toString(level);
     j["message"] = message;

--- a/src/utils/process_exec.cpp
+++ b/src/utils/process_exec.cpp
@@ -93,7 +93,8 @@ ProcessExecutor::processExecStdout(const std::vector<std::string> &args,
 }
 
 namespace {
-std::shared_ptr<IProcessExecutor> g_executor = std::make_shared<ProcessExecutor>();
+std::shared_ptr<IProcessExecutor> g_executor_owner = std::make_shared<ProcessExecutor>();
+IProcessExecutor* g_executor = g_executor_owner.get();
 }
 
 IProcessExecutor &getProcessExecutor() {
@@ -101,7 +102,8 @@ IProcessExecutor &getProcessExecutor() {
 }
 
 void setProcessExecutor(std::shared_ptr<IProcessExecutor> executor) {
-    g_executor = std::move(executor);
+    g_executor_owner = std::move(executor);
+    g_executor = g_executor_owner.get();
 }
 
 std::expected<std::future<int>, std::string>

--- a/src/utils/yaml/configuration.cpp
+++ b/src/utils/yaml/configuration.cpp
@@ -9,7 +9,6 @@
 #include <functional>
 #include <optional>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -27,29 +26,32 @@ namespace fs = std::filesystem;
 namespace {
 
 YAML::Node getDefaultConfiguration() {
-    YAML::Node root;
-    root["meta"]["min_ver"] = "0.0.1";
-    root["meta"]["generator"] = "cbe";
-    root["manifest"]["name"] = "name";
-    root["manifest"]["type"] = "BINARY";
-    root["manifest"]["version"] = "0.0.1";
-    root["manifest"]["provides"] = "";
-    root["manifest"]["tooling"]["CC"] = "clang";
-    root["manifest"]["tooling"]["CXX"] = "clang++";
-    root["manifest"]["tooling"]["FMT"] = "clang-format";
-    root["manifest"]["tooling"]["LINTER"] = "clang-tidy";
-    root["manifest"]["tooling"]["CCFLAGS"] = "";
-    root["manifest"]["tooling"]["CXXFLAGS"] = "";
-    root["manifest"]["tooling"]["LDFLAGS"] = "";
-    root["manifest"]["tooling"]["doc"]["engine"] = "doxygen";
-    root["manifest"]["tooling"]["doc"]["config"] = "Doxyfile";
-    root["manifest"]["tooling"]["doc"]["out_dir"] = "docs/";
-    root["manifest"]["dirs"]["include"] = std::vector<std::string>{};
-    root["manifest"]["dirs"]["source"] = std::vector<std::string>{};
-    root["manifest"]["dirs"]["build"] = "";
-    root["dependencies"] = std::vector<YAML::Node>{};
-    root["features"] = YAML::Node(YAML::NodeType::Map);
-    return root;
+    static YAML::Node defaults = []() {
+        YAML::Node root;
+        root["meta"]["min_ver"] = "0.0.1";
+        root["meta"]["generator"] = "cbe";
+        root["manifest"]["name"] = "name";
+        root["manifest"]["type"] = "BINARY";
+        root["manifest"]["version"] = "0.0.1";
+        root["manifest"]["provides"] = "";
+        root["manifest"]["tooling"]["CC"] = "clang";
+        root["manifest"]["tooling"]["CXX"] = "clang++";
+        root["manifest"]["tooling"]["FMT"] = "clang-format";
+        root["manifest"]["tooling"]["LINTER"] = "clang-tidy";
+        root["manifest"]["tooling"]["CCFLAGS"] = "";
+        root["manifest"]["tooling"]["CXXFLAGS"] = "";
+        root["manifest"]["tooling"]["LDFLAGS"] = "";
+        root["manifest"]["tooling"]["doc"]["engine"] = "doxygen";
+        root["manifest"]["tooling"]["doc"]["config"] = "Doxyfile";
+        root["manifest"]["tooling"]["doc"]["out_dir"] = "docs/";
+        root["manifest"]["dirs"]["include"] = std::vector<std::string>{};
+        root["manifest"]["dirs"]["source"] = std::vector<std::string>{};
+        root["manifest"]["dirs"]["build"] = "";
+        root["dependencies"] = std::vector<YAML::Node>{};
+        root["features"] = YAML::Node(YAML::NodeType::Map);
+        return root;
+    }();
+    return YAML::Clone(defaults);
 }
 
 std::string verMax(std::string s1, std::string s2) {
@@ -188,15 +190,13 @@ void mergeHelper(YAML::Node &composite, const std::string &new_profile_name, con
 
     auto check_conflict = [&](const std::string &dotpath, const std::string &incoming_val) {
         try {
-            auto resolve = [](YAML::Node node, const std::string &path) -> std::string {
-                for (const auto &seg : splitPath(path))
-                    node = node[seg];
-                return node.as<std::string>();
-            };
-            std::string current_val = resolve(YAML::Clone(composite), dotpath);
-            std::string default_val = resolve(YAML::Clone(defaults), dotpath);
+            auto current_node = traverse(dotpath, composite);
+            auto default_node = traverse(dotpath, defaults);
 
-            if (current_val != incoming_val && current_val != default_val) {
+            std::string current_val = current_node ? current_node->as<std::string>() : "";
+            std::string default_val = default_node ? default_node->as<std::string>() : "";
+
+            if (!current_val.empty() && current_val != incoming_val && current_val != default_val) {
                 catalyst::logger.warn(
                     "Profile '{}' overrides '{}': '{}' -> '{}'", new_profile_name, dotpath, current_val, incoming_val);
             }
@@ -374,11 +374,12 @@ void merge(YAML::Node &composite, const std::string &profile_name, const fs::pat
 
 Configuration::Configuration(const std::vector<std::string> &profiles, const std::filesystem::path &root_dir) {
     std::vector<std::string> profile_names;
+    profile_names.reserve(profiles.size());
     for (const auto &p : profiles) {
-        if (std::ranges::find(profile_names, p) == profile_names.end()) {
-            profile_names.push_back(p);
+        if (!profile_names.empty() && profile_names.back() == p) {
+            catalyst::logger.warn("Adjacent duplicate profile '{}' ignored during composition.", p);
         } else {
-            catalyst::logger.warn("Duplicate profile '{}' ignored during composition.", p);
+            profile_names.push_back(p);
         }
     }
     catalyst::logger.debug("Composing profiles: {}.", profile_names);
@@ -394,16 +395,7 @@ Configuration::Configuration(const std::vector<std::string> &profiles, const std
 }
 
 bool Configuration::has(const std::string &key) const {
-    std::vector<std::string> segments = splitPath(key);
-    YAML::Node current = YAML::Clone(root);
-
-    for (const auto &segment : segments) {
-        if (!current[segment]) {
-            return false;
-        }
-        current = current[segment];
-    }
-    return true;
+    return traverse(key, root).has_value();
 }
 
 std::optional<std::string> Configuration::getString(const std::string &key) const {


### PR DESCRIPTION
- **perf: remove dead concatArgv code in dispatch.cpp**
- **perf: use \n instead of std::endl for logging**
- **perf: store CATALYST_VISITED env result in local variable**
- **perf(tidy): use lock_guard instead of manual mutex lock/unlock**
- **perf: reserve string capacity when joining hook arguments**
- **perf: dedup trim lambdas in find_dep/system.cpp**
- **perf(download): optimize randomString generation**
- **perf(clean): use DirectoryChangeGuard for exception-safe CWD management**
- **perf(install): use fs::copy for recursive copy to reduce overhead**
- **perf(log): reuse thread-local JSON object**
- **perf: use unordered_set for extension checks**
- **perf(yaml): rewrite verMax, splitPath, and profile dedup for performance**
- **perf(generate): use unordered_set for isEnabled check**
- **perf(hooks): avoid unconditional string formatting for index replacements**
- **perf(process_exec): use raw pointer to avoid atomic ref counting**
- **perf(fmt): invoke clang-format once with all files**
- **perf(fetch): optimize cycle detection with normalized paths and string_view**
- **perf(exec): avoid mutating global env by passing env to processExec**
