### PR TITLE
feat(add): support adding dependencies to composite CATALYST.yaml

### DIFF
--- a/include/catalyst/utils/yaml/load_profile_file.hpp
+++ b/include/catalyst/utils/yaml/load_profile_file.hpp
@@ -6,6 +6,13 @@
 #include <yaml-cpp/yaml.h>
 
 namespace catalyst::utils::yaml {
-std::expected<YAML::Node, std::string>
+
+struct ProfileFile {
+    YAML::Node root_node;
+    YAML::Node profile_node;
+    std::filesystem::path path;
+};
+
+std::expected<ProfileFile, std::string>
 loadProfileFile(const std::string &profile, const std::filesystem::path &root_dir = std::filesystem::current_path());
-}
+} // namespace catalyst::utils::yaml

--- a/include/catalyst/utils/yaml/profile_write_back.hpp
+++ b/include/catalyst/utils/yaml/profile_write_back.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <expected>
+#include <string>
 
+#include <catalyst/utils/yaml/load_profile_file.hpp>
 #include <yaml-cpp/node/node.h>
 #include <yaml-cpp/yaml.h>
 
 namespace catalyst::utils::yaml {
-std::expected<void, std::string> profileWriteBack(const std::string &profile_name, const YAML::Node &node);
+std::expected<void, std::string> profileWriteBack(const ProfileFile &profile_file);
 }

--- a/src/subcommands/add/add_git.cpp
+++ b/src/subcommands/add/add_git.cpp
@@ -15,7 +15,8 @@ std::expected<void, std::string> addToProfile(const std::string &profile, const 
     if (!res) {
         return std::unexpected(res.error());
     }
-    YAML::Node profile_node = res.value();
+    auto profile_file = res.value();
+    YAML::Node profile_node = profile_file.profile_node;
 
     if (!profile_node["dependencies"]) {
         profile_node["dependencies"] = YAML::Node(YAML::NodeType::Sequence);
@@ -64,7 +65,7 @@ std::expected<void, std::string> addToProfile(const std::string &profile, const 
 
     dependencies.push_back(new_dep);
 
-    return catalyst::utils::yaml::profileWriteBack(profile, profile_node);
+    return catalyst::utils::yaml::profileWriteBack(profile_file);
 }
 } // namespace
 

--- a/src/subcommands/add/add_local.cpp
+++ b/src/subcommands/add/add_local.cpp
@@ -15,7 +15,8 @@ std::expected<void, std::string> addToProfile(const std::string &profile, const 
     if (!res) {
         return std::unexpected(res.error());
     }
-    YAML::Node profile_node = res.value();
+    auto profile_file = res.value();
+    YAML::Node profile_node = profile_file.profile_node;
 
     if (!profile_node["dependencies"]) {
         profile_node["dependencies"] = YAML::Node(YAML::NodeType::Sequence);
@@ -45,7 +46,7 @@ std::expected<void, std::string> addToProfile(const std::string &profile, const 
 
     dependencies.push_back(new_dep);
 
-    return catalyst::utils::yaml::profileWriteBack(profile, profile_node);
+    return catalyst::utils::yaml::profileWriteBack(profile_file);
 }
 } // namespace
 

--- a/src/subcommands/add/add_system.cpp
+++ b/src/subcommands/add/add_system.cpp
@@ -15,7 +15,8 @@ std::expected<void, std::string> addToProfile(const std::string &profile, const 
     if (!res) {
         return std::unexpected(res.error());
     }
-    YAML::Node profile_node = res.value();
+    auto profile_file = res.value();
+    YAML::Node profile_node = profile_file.profile_node;
 
     if (!profile_node["dependencies"]) {
         profile_node["dependencies"] = YAML::Node(YAML::NodeType::Sequence);
@@ -45,7 +46,7 @@ std::expected<void, std::string> addToProfile(const std::string &profile, const 
 
     dependencies.push_back(new_dep);
 
-    return catalyst::utils::yaml::profileWriteBack(profile, profile_node);
+    return catalyst::utils::yaml::profileWriteBack(profile_file);
 }
 } // namespace
 

--- a/src/subcommands/add/add_vcpkg.cpp
+++ b/src/subcommands/add/add_vcpkg.cpp
@@ -16,7 +16,8 @@ std::expected<void, std::string> addToProfile(const std::string &profile, const 
     if (!res) {
         return std::unexpected(res.error());
     }
-    YAML::Node profile_node = res.value();
+    auto profile_file = res.value();
+    YAML::Node profile_node = profile_file.profile_node;
 
     if (!profile_node["dependencies"]) {
         profile_node["dependencies"] = YAML::Node(YAML::NodeType::Sequence);
@@ -53,7 +54,7 @@ std::expected<void, std::string> addToProfile(const std::string &profile, const 
 
     dependencies.push_back(new_dep);
 
-    return catalyst::utils::yaml::profileWriteBack(profile, profile_node);
+    return catalyst::utils::yaml::profileWriteBack(profile_file);
 }
 } // namespace
 

--- a/src/utils/yaml/load_profile_file.cpp
+++ b/src/utils/yaml/load_profile_file.cpp
@@ -11,10 +11,25 @@
 #include "catalyst/utils/log/log.hpp"
 
 namespace catalyst::utils::yaml {
-std::expected<YAML::Node, std::string> loadProfileFile(const std::string &profile,
-                                                       const std::filesystem::path &root_dir) {
+std::expected<ProfileFile, std::string> loadProfileFile(const std::string &profile,
+                                                        const std::filesystem::path &root_dir) {
     catalyst::logger.debug("Loading profile file: {} from {}", profile, root_dir.string());
     namespace fs = std::filesystem;
+
+    fs::path combined_path = root_dir / "CATALYST.yaml";
+    if (fs::exists(combined_path)) {
+        try {
+            YAML::Node ret = YAML::LoadFile(combined_path);
+            if (!ret[profile]) {
+                ret[profile] = YAML::Node(YAML::NodeType::Map);
+            }
+            catalyst::logger.debug("Combined profile file loaded successfully.");
+            return ProfileFile{ret, ret[profile], combined_path};
+        } catch (YAML::Exception &err) {
+            return std::unexpected(std::format("Failed to parse YAML file: {}", err.what()));
+        }
+    }
+
     fs::path profile_path = root_dir;
     if (profile == "common")
         profile_path /= "catalyst.yaml";
@@ -29,7 +44,7 @@ std::expected<YAML::Node, std::string> loadProfileFile(const std::string &profil
     try {
         YAML::Node ret = YAML::LoadFile(profile_path);
         catalyst::logger.debug("Profile file loaded successfully.");
-        return ret;
+        return ProfileFile{ret, ret, profile_path};
     } catch (YAML::Exception &err) {
         return std::unexpected(std::format("Failed to parse YAML file: {}", err.what()));
     }

--- a/src/utils/yaml/profile_write_back.cpp
+++ b/src/utils/yaml/profile_write_back.cpp
@@ -9,25 +9,14 @@
 #include "catalyst/utils/log/log.hpp"
 
 namespace catalyst::utils::yaml {
-std::expected<void, std::string> profileWriteBack(const std::string &profile_name, const YAML::Node &node) {
-    catalyst::logger.debug("Writing profile to file: {}", profile_name);
-    namespace fs = std::filesystem;
-    fs::path profile_path;
-    if (profile_name == "common")
-        profile_path = "catalyst.yaml";
-    else
-        profile_path = std::format("catalyst_{}.yaml", profile_name);
+std::expected<void, std::string> profileWriteBack(const ProfileFile &profile_file) {
+    catalyst::logger.debug("Writing profile file: {}", profile_file.path.string());
 
-    catalyst::logger.debug("Profile path: {}", profile_path.string());
-    if (!fs::exists(profile_path)) {
-        catalyst::logger.debug("Creating new profile file: {}", profile_path.string());
-    }
-
-    std::ofstream profile_file{profile_path};
+    std::ofstream profile_file_out{profile_file.path};
     YAML::Emitter emmiter;
-    emmiter << node;
+    emmiter << profile_file.root_node;
     // NOLINTBEGIN(performance-avoid-endl)
-    profile_file << emmiter.c_str() << std::endl;
+    profile_file_out << emmiter.c_str() << std::endl;
     // NOLINTEND(performance-avoid-endl)
     catalyst::logger.debug("Profile file written successfully.");
     return {};


### PR DESCRIPTION
Updated all add subcommands to automatically check for and modify the composite CATALYST.yaml file if it exists, before falling back to individual profile files. Introduced a ProfileFile struct to correctly route writes to the underlying file path.