### PR TITLE
1.9.1

### DIFF
--- a/CATALYST.yaml
+++ b/CATALYST.yaml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/CatalystCPP/catalyst-build-system/refs/heads/master/catalyst.schema.json
 common:
   meta:
-    min_ver: 1.0.0
+    min_ver: 1.8.0
   manifest:
     name: catalyst
     type: BINARY
-    version: 1.9.0
+    version: 1.9.1-dev
     description: Catalyst is a Declarative C++ Build System
     provides: catalyst
     toolchain: tc_catalyst.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,10 @@ Refer to the `.clang-format` file in the root directory for exact rules.
 - `docs/`: Documentation (MkDocs format).
 - `tests/`: Unit and integration tests.
 
+## Release and Support Policy
+
+See the [release and support policy](README.md#release-and-support-policy) prior to contributing.
+
 ## License
 
 By contributing to Catalyst, you agree that your contributions will be licensed under the [Apache 2.0 License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ See the full [CLI Reference](https://catalystcpp.github.io/catalyst-build-system
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and patch guidelines.
 
+## Release and Support Policy
+
+Published versions are available on [GitHub Releases](https://github.com/CatalystCPP/catalyst-build-system/releases).
+The following policy takes effect with Catalyst 2.0.0.
+
+### Release Cadence
+
+- A patch release is scheduled every week (Monday 00:00 PST). A patch may contain no functional changes.
+- A minor release is scheduled every five weeks.
+- A major release is scheduled every 25 weeks.
+- Each week, the highest applicable release is shipped. A major release on a major-release week, a minor release on a minor-release week, and a patch release otherwise.
+
+### Support Policy
+
+- Every `x.0` major release line is a long-term support (LTS) line.
+- An LTS line is supported until `x+3.0.0` is released, approximately 75 weeks later.
+- Support applies to the latest `x.0.k` patch, not the original `x.0.0` artifact.
+- Within the current major version, the latest patch of every minor line is supported until the next major version is released.
+- No support is guaranteed for other releases.
+
 ## License
 
 Apache License 2.0, see [LICENSE.md](LICENSE.md).

--- a/catalyst.schema.json
+++ b/catalyst.schema.json
@@ -134,7 +134,8 @@
                     "type": "array",
                     "items": { "type": "string" }
                   }
-                }
+                },
+                "required": ["triplet"]
               },
               {
                 "properties": {

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -27,14 +27,16 @@ catalyst add git [OPTIONS] [remote]
 
 
 POSITIONALS:
-  remote TEXT                 
+  remote TEXT                 remote git repository URL
 
 OPTIONS:
   -h,     --help              Print this help message and exit
-  -n,     --name TEXT         
+  -n,     --name TEXT         dependency name
   -v,     --version TEXT [latest]  
-  -f,     --features TEXT ... 
-  -p,     --profiles TEXT ... 
+                              dependency version
+  -f,     --features TEXT ... features to enable
+  -p,     --profiles TEXT [[common]]  ... 
+                              profiles to add the dependency to
 ```
 
 ### system
@@ -48,9 +50,11 @@ catalyst add system [OPTIONS]
 OPTIONS:
   -h,     --help              Print this help message and exit
   -n,     --name TEXT REQUIRED 
-  -l,     --lib TEXT          
-  -i,     --inc TEXT          
-  -p,     --profiles TEXT ... 
+                              dependency name
+  -l,     --lib TEXT          system library name or path
+  -i,     --inc TEXT          system include path
+  -p,     --profiles TEXT [[common]]  ... 
+                              profiles to add the dependency to
 ```
 
 ### local
@@ -62,13 +66,15 @@ catalyst add local [OPTIONS] path
 
 
 POSITIONALS:
-  path TEXT REQUIRED          
+  path TEXT REQUIRED          local package directory path
 
 OPTIONS:
   -h,     --help              Print this help message and exit
   -n,     --name TEXT REQUIRED 
-  -p,     --profiles TEXT ... 
-  -f,     --features TEXT ... 
+                              dependency name
+  -p,     --profiles TEXT [[common]]  ... 
+                              profiles to add the dependency to
+  -f,     --features TEXT ... features to enable
 ```
 
 ### vcpkg
@@ -82,10 +88,14 @@ catalyst add vcpkg [OPTIONS]
 OPTIONS:
   -h,     --help              Print this help message and exit
   -n,     --name TEXT REQUIRED 
+                              dependency name
   -t,     --triplet TEXT REQUIRED 
+                              vcpkg triplet
   -v,     --version TEXT [latest]  
+                              dependency version
   -p,     --profiles TEXT [[common]]  ... 
-  -f,     --features TEXT ... 
+                              profiles to add the dependency to
+  -f,     --features TEXT ... features to enable
 ```
 
 ### conan
@@ -99,8 +109,11 @@ catalyst add conan [OPTIONS]
 OPTIONS:
   -h,     --help              Print this help message and exit
   -n,     --name TEXT REQUIRED 
+                              dependency name
   -v,     --version TEXT REQUIRED 
+                              dependency version
   -p,     --profiles TEXT [[common]]  ... 
+                              profiles to add the dependency to
 ```
 
 ## Examples

--- a/docs/cli/clean.md
+++ b/docs/cli/clean.md
@@ -9,7 +9,8 @@ catalyst clean [OPTIONS]
 
 OPTIONS:
   -h,     --help              Print this help message and exit
-  -p,     --profile TEXT ...  
+  -p,     --profiles TEXT [[common]]  ... 
+                              Profile composition to clean.
   -i,     --intermediates     Clean intermediate files only.
 ```
 

--- a/docs/cli/fetch.md
+++ b/docs/cli/fetch.md
@@ -9,7 +9,8 @@ catalyst fetch [OPTIONS]
 
 OPTIONS:
   -h,     --help              Print this help message and exit
-  -p,     --profiles TEXT ... 
+  -p,     --profiles TEXT [[common]]  ... 
+                              Profile composition to fetch.
 ```
 
 ## Details

--- a/docs/cli/fetch.md
+++ b/docs/cli/fetch.md
@@ -18,7 +18,8 @@ OPTIONS:
 This command is usually run automatically by `catalyst build`, but can be run manually to prepare the environment (e.g., in CI/CD pipelines).
 
 - **Git**: Clones repositories.
-- **Vcpkg**: Installs packages.
+- **Vcpkg**: Generates a versioned manifest and installs packages into the
+  composed profile's build tree.
 - **System**: Verifies presence via pkg-config.
 
 ## Examples

--- a/docs/cli/fmt.md
+++ b/docs/cli/fmt.md
@@ -9,6 +9,8 @@ catalyst fmt [OPTIONS]
 
 OPTIONS:
   -h,     --help              Print this help message and exit
+  -p,     --profiles TEXT [[common]]  ...
+                              Profile composition to build.
 ```
 
 ## Details

--- a/docs/cli/generate.md
+++ b/docs/cli/generate.md
@@ -9,8 +9,9 @@ catalyst generate [OPTIONS]
 
 OPTIONS:
   -h,     --help              Print this help message and exit
-  -p,     --profiles TEXT ... 
-  -f,     --features TEXT ... 
+  -p,     --profiles TEXT [[common]]  ... 
+                              Profile composition to generate.
+  -f,     --features TEXT ... Features to enable.
   -b,     --backend TEXT      Backend to use for generation (ninja, gmake, cob).
 ```
 

--- a/docs/cli/ide-sync.md
+++ b/docs/cli/ide-sync.md
@@ -9,7 +9,7 @@ catalyst ide-sync [OPTIONS]
 
 OPTIONS:
   -h,     --help              Print this help message and exit
-  -p,     --profiles TEXT [common]  ... 
+  -p,     --profiles TEXT [[common]]  ... 
                               Profiles to use from the configuration file
           --ides ENUM ...     IDEs to generate project files for: vscode, clion
   -f,     --force-ide [0]     force emitting IDE config even if one already exists

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -26,8 +26,7 @@ OPTIONS:
                               source directories
           --build-dir TEXT [build]  
                               build directory
-          --ides ENUM:value in {clion->1,vscode->0} OR {1,0} ... 
-                              IDEs to generate project files for
+          --ides ENUM ...     IDEs to generate project files for (vscode, clion)
   -p,     --profile TEXT [common]  
                               the profile to initialize
   -f,     --force-ide [0]     force emitting IDE config even if one already exists

--- a/docs/cli/lock.md
+++ b/docs/cli/lock.md
@@ -18,7 +18,8 @@ OPTIONS:
 The `lock` command resolves all dependencies declared in your `catalyst.yaml` (and workspace member manifests) to specific, reproducible states.
 
 - **Git**: Resolves branches, tags, or "latest" to specific 40-character commit hashes using `git ls-remote`.
-- **Vcpkg**: Records the version and triplet.
+- **Vcpkg**: Resolves through manifest mode and records the actual installed
+  version, port revision, triplet, and builtin registry baseline.
 - **System/Local**: Records the source type and paths.
 
 In a **Workspace**, a single `catalyst.lock` is generated at the workspace root, containing a consolidated set of pinned dependencies for all workspace members.

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -9,7 +9,8 @@ catalyst run [OPTIONS]
 
 OPTIONS:
   -h,     --help              Print this help message and exit
-  -p,     --profiles TEXT [common]  ... 
+  -p,     --profiles TEXT [[common]]  ... 
+                              Profile composition to run.
   -P,     --params TEXT ...   
 ```
 

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -31,8 +31,8 @@ Uses `vcpkg` to satisfy the dependency.
 |---|---|---|
 | `name` | Yes | Package name in vcpkg. |
 | `source` | Yes | Must be `vcpkg`. |
-| `version` | No | Package version (informative only; vcpkg classic mode resolves versions based on VCPKG_ROOT's registry). |
-| `triplet` | No | vcpkg triplet (e.g., `x64-linux`). |
+| `version` | No | Exact package version. Catalyst emits a vcpkg manifest override; omit it or use `latest` to select the baseline version. |
+| `triplet` | Yes | vcpkg triplet (e.g., `x64-linux`). |
 | `linkage` | No | `static` or `shared` (default `shared`). Controls which library artifacts are scanned. |
 | `transitive` | No | Automatically resolve and link the package's transitive vcpkg dependencies (default `true`). |
 | `using` | No | List of features to enable. |
@@ -41,6 +41,7 @@ Uses `vcpkg` to satisfy the dependency.
 - name: nlohmann-json
   source: vcpkg
   version: 3.11.2
+  triplet: x64-linux
 ```
 
 #### Transitive dependencies
@@ -48,7 +49,7 @@ Uses `vcpkg` to satisfy the dependency.
 vcpkg packages each dependency as its own port, so a single library can rely on
 several others installed alongside it (for example, `ryml` depends on `c4core`).
 By default Catalyst discovers and links these automatically by reading vcpkg's
-installed-package database (`$VCPKG_ROOT/installed/vcpkg/status`), so you only
+profile-local installed-package database (`<build-dir>/vcpkg_installed/vcpkg/status`), so you only
 need to declare the packages you use directly:
 
 ```yaml
@@ -63,6 +64,11 @@ link or include artifacts, and packages are emitted in a valid static-link order
 (a package always precedes the packages it depends on). Set `transitive: false`
 on a dependency to opt out and link only that package — useful if you prefer to
 pin every transitive package explicitly.
+
+Catalyst uses vcpkg manifest mode and installs packages beneath the composed
+profile's generated build tree (`<build-dir>/vcpkg_installed`). The generated
+manifest records the current vcpkg registry commit as its builtin baseline and
+uses overrides for every exact version declared by the project or lockfile.
 
 ### 3. `local`
 Builds a dependency found on the local filesystem.
@@ -158,7 +164,8 @@ Catalyst supports pinning dependency versions to ensure that everyone working on
 
 By running [`catalyst lock`](../cli/lock.md), you generate a `catalyst.lock` file. This file pins:
 - **Git** dependencies to specific 40-character commit hashes.
-- **Vcpkg** dependencies to their current versions and triplets.
+- **Vcpkg** dependencies to their resolved versions, port revisions, triplets,
+  and builtin registry baseline.
 - **Local/System** dependencies to their paths.
 
 When a `catalyst.lock` is present, `catalyst fetch` and `catalyst build` will prioritize its contents over the loose version constraints in `catalyst.yaml`.

--- a/include/catalyst/subcommands/generate.hpp
+++ b/include/catalyst/subcommands/generate.hpp
@@ -21,6 +21,7 @@ struct Parse {
     std::vector<std::string> profiles;
     std::vector<std::string> enabled_features;
     std::string backend;
+    bool skip_pre_generate = false;
 };
 
 struct FindRes {
@@ -33,6 +34,7 @@ struct FindRes {
 Result<utils::yaml::Configuration> profileComposition(const std::vector<std::string> &profiles);
 std::pair<CLI::App *, std::unique_ptr<Parse>> parse(CLI::App &app);
 Result<void> action(const Parse &);
+std::string buildFilename(std::string_view generator);
 
 Result<std::string> libPath(const utils::yaml::Configuration &profile_comp,
                             const std::vector<std::string> &profiles,

--- a/include/catalyst/subcommands/generate.hpp
+++ b/include/catalyst/subcommands/generate.hpp
@@ -43,10 +43,11 @@ Result<FindRes>
 findDep(const std::string &build_dir, ryml::ConstNodeRef dep, const catalyst::toolchain::ToolchainDef &tc);
 Result<FindRes> findLocal(ryml::ConstNodeRef dep, const catalyst::toolchain::ToolchainDef &tc);
 Result<FindRes> findSystem(ryml::ConstNodeRef dep, const catalyst::toolchain::ToolchainDef &tc);
-Result<FindRes> findVcpkg(ryml::ConstNodeRef dep, const catalyst::toolchain::ToolchainDef &tc);
+Result<FindRes>
+findVcpkg(const std::string &build_dir, ryml::ConstNodeRef dep, const catalyst::toolchain::ToolchainDef &tc);
 
 /// Parsed view of vcpkg's installed-package database
-/// ($VCPKG_ROOT/installed/vcpkg/status), which is in Debian-control format.
+/// (<build-dir>/vcpkg_installed/vcpkg/status), which is in Debian-control format.
 struct VcpkgStatusDb {
     /// Maps an installed package to its direct dependency names. The key is
     /// "<name>\x1f<triplet>"; build it with vcpkgStatusKey(). Dependencies from

--- a/include/catalyst/utils/toolchain.hpp
+++ b/include/catalyst/utils/toolchain.hpp
@@ -2,6 +2,7 @@
 
 #include <expected>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -10,6 +11,8 @@
 #include "catalyst/utils/result.hpp"
 
 namespace catalyst::toolchain {
+
+inline constexpr std::string_view RESOLVED_TOOLCHAIN_STORE_FILENAME = "catalyst__tc_store";
 
 struct ToolchainDef {
     std::string name = "gcc";
@@ -29,6 +32,8 @@ struct ToolchainDef {
         std::string bmi = ".pcm";
         std::vector<std::string> library_scan;
         std::vector<std::string> shell_scripts = {".bat", ".cmd"};
+
+        bool operator==(const Extensions &) const = default;
     } extensions;
 
     struct Flags {
@@ -37,12 +42,16 @@ struct ToolchainDef {
         std::string lib = "-l{name}";
         std::string define = "-D{name}={value}";
         std::string define_empty = "-D{name}";
+
+        bool operator==(const Flags &) const = default;
     } flags;
 
     struct CompilerDef {
         std::string executable;
         std::string flags; // base compiler flags, interpolated as {cflags}/{cxxflags}
         std::string command;
+
+        bool operator==(const CompilerDef &) const = default;
     };
 
     struct Compiler {
@@ -53,6 +62,8 @@ struct ToolchainDef {
                            .flags = {},
                            .command =
                                "{cxx} {cxxflags} -MMD -MF {object}.d -c {source} -o {object} {includes} {defines}"};
+
+        bool operator==(const Compiler &) const = default;
     } compiler;
 
     struct Linker {
@@ -60,12 +71,18 @@ struct ToolchainDef {
         std::string flags; // base linker flags, interpolated as {ldflags}
         std::string executable_command = "{linker} {objects} -o {output} {ldflags} {lib_dirs} {libs}";
         std::string shared_lib_command = "{linker} -shared {objects} -o {output} {ldflags} {lib_dirs} {libs}";
+
+        bool operator==(const Linker &) const = default;
     } linker;
 
     struct Archiver {
         std::string executable = "ar";
         std::string command = "{archiver} rcs {output} {objects}";
+
+        bool operator==(const Archiver &) const = default;
     } archiver;
+
+    bool operator==(const ToolchainDef &) const = default;
 };
 
 // Expands a template string replacing {key} with the corresponding value from vars
@@ -73,5 +90,14 @@ std::string expandTemplate(std::string_view tmpl, const std::unordered_map<std::
 
 // Parse a ToolchainDef from a YAML file
 Result<ToolchainDef> parseToolchain(const std::filesystem::path &path);
+
+// Resolve the configured toolchain, or the built-in defaults when no path is configured.
+Result<ToolchainDef> resolveToolchain(const std::optional<std::filesystem::path> &path);
+
+// Serialize every effective field as deterministic YAML, without inheritance metadata.
+std::string serializeToolchain(const ToolchainDef &toolchain);
+
+// Serialize the backend identity and effective toolchain for the per-build-directory store.
+std::string serializeToolchainStore(const ToolchainDef &toolchain, std::string_view generator);
 
 } // namespace catalyst::toolchain

--- a/include/catalyst/utils/vcpkg.hpp
+++ b/include/catalyst/utils/vcpkg.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "catalyst/utils/result.hpp"
+
+namespace catalyst::utils::vcpkg {
+
+struct Dependency {
+    std::string name;
+    std::string version;
+    std::string triplet;
+    std::vector<std::string> features;
+    std::optional<int> port_version;
+};
+
+struct InstalledPackage {
+    std::string version;
+    int port_version = 0;
+};
+
+struct InstallResult {
+    std::string builtin_baseline;
+    std::filesystem::path install_root;
+    std::unordered_map<std::string, InstalledPackage> packages;
+};
+
+[[nodiscard]] std::string statusKey(std::string_view name, std::string_view triplet);
+
+[[nodiscard]] Result<std::string> currentBuiltinBaseline(const std::filesystem::path &vcpkg_root);
+
+[[nodiscard]] Result<std::string> manifestJson(std::span<const Dependency> dependencies,
+                                               std::string_view builtin_baseline);
+
+[[nodiscard]] std::unordered_map<std::string, InstalledPackage> parseInstalledVersions(std::string_view status);
+
+[[nodiscard]] Result<InstallResult> install(std::span<const Dependency> dependencies,
+                                            const std::filesystem::path &build_dir,
+                                            const std::optional<std::string> &builtin_baseline = std::nullopt);
+
+} // namespace catalyst::utils::vcpkg

--- a/src/subcommands/build/action.cpp
+++ b/src/subcommands/build/action.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -15,6 +16,7 @@
 #include "catalyst/subcommands/generate.hpp"
 #include "catalyst/utils/log/log.hpp"
 #include "catalyst/utils/result.hpp"
+#include "catalyst/utils/toolchain.hpp"
 #include "catalyst/utils/watcher.hpp"
 #include "catalyst/utils/yaml/configuration.hpp"
 #include "catalyst/workspace.hpp"
@@ -184,6 +186,40 @@ Result<void> generateCompileCommands(const fs::path &build_dir, const std::strin
     return {}; // don't fail if we don't know how to generate compile commands for this generator, it's not critical
 }
 
+Result<bool>
+toolchainChanged(const utils::yaml::Configuration &config, const fs::path &store_path, std::string_view generator) {
+    std::optional<fs::path> toolchain_path;
+    if (auto configured_path = config.getString("manifest.toolchain"))
+        toolchain_path = *configured_path;
+
+    auto resolved_toolchain = catalyst::toolchain::resolveToolchain(toolchain_path);
+    if (!resolved_toolchain)
+        return std::unexpected(resolved_toolchain.error());
+
+    std::error_code ec;
+    if (!fs::exists(store_path, ec)) {
+        if (ec)
+            return std::unexpected(
+                std::format("Failed to inspect resolved toolchain store {}: {}", store_path.string(), ec.message()));
+        return true;
+    }
+
+    std::ifstream store{store_path, std::ios::binary};
+    if (!store)
+        return std::unexpected(std::format("Failed to open {} for reading", store_path.string()));
+
+    std::string stored_toolchain;
+    char buffer[4096];
+    while (store) {
+        store.read(buffer, sizeof(buffer));
+        stored_toolchain.append(buffer, static_cast<size_t>(store.gcount()));
+    }
+    if (!store.eof())
+        return std::unexpected(std::format("Failed to read {}", store_path.string()));
+
+    return stored_toolchain != catalyst::toolchain::serializeToolchainStore(*resolved_toolchain, generator);
+}
+
 } // namespace
 
 Result<void> action(const Parse &parse_args) {
@@ -260,12 +296,31 @@ Result<void> action(const Parse &parse_args) {
             return;
         }
 
+        catalyst::logger.info("Running pre-generate hooks.");
+        if (auto res = hooks::preGenerate(config); !res) {
+            catalyst::logger.error("Pre-generate hook failed: {}", res.error());
+            result = std::unexpected(res.error());
+            return;
+        }
+
         fs::path build_dir = config.getBuildDir();
         std::string generator =
             parse_args.backend.empty() ? config.getString("meta.generator").value_or("cob") : parse_args.backend;
-        std::string build_filename = (generator == "ninja") ? "build.ninja" : "catalyst.build";
+        std::string build_filename = catalyst::generate::buildFilename(generator);
 
         bool needs_regen = !fs::exists(build_dir / build_filename) || parse_args.regen;
+        if (!needs_regen) {
+            const fs::path toolchain_store = build_dir / catalyst::toolchain::RESOLVED_TOOLCHAIN_STORE_FILENAME;
+            auto toolchain_changed = toolchainChanged(config, toolchain_store, generator);
+            if (!toolchain_changed) {
+                catalyst::logger.error("Failed to resolve toolchain state: {}", toolchain_changed.error());
+                result = std::unexpected(toolchain_changed.error());
+                return;
+            }
+            needs_regen = *toolchain_changed;
+            if (needs_regen)
+                catalyst::logger.debug("Resolved toolchain changed; build files must be regenerated.");
+        }
         if (!needs_regen) {
             auto build_time = fs::last_write_time(build_dir / build_filename);
             if (fs::exists("CATALYST.yaml") && fs::last_write_time("CATALYST.yaml") > build_time) {
@@ -286,16 +341,10 @@ Result<void> action(const Parse &parse_args) {
             catalyst::logger.info("Generating build files.");
             auto res = catalyst::generate::action({.profiles = parse_args.profiles,
                                                    .enabled_features = parse_args.enabled_features,
-                                                   .backend = parse_args.backend});
+                                                   .backend = parse_args.backend,
+                                                   .skip_pre_generate = true});
             if (!res) {
                 catalyst::logger.error("Failed to generate build files: {}", res.error());
-                result = std::unexpected(res.error());
-                return;
-            }
-        } else {
-            catalyst::logger.info("Running pre-generate hooks.");
-            if (auto res = hooks::preGenerate(config); !res) {
-                catalyst::logger.error("Pre-generate hook failed: {}", res.error());
                 result = std::unexpected(res.error());
                 return;
             }

--- a/src/subcommands/fetch/action.cpp
+++ b/src/subcommands/fetch/action.cpp
@@ -19,6 +19,7 @@
 #include "catalyst/utils/log/log.hpp"
 #include "catalyst/utils/result.hpp"
 #include "catalyst/utils/toolchain.hpp"
+#include "catalyst/utils/vcpkg.hpp"
 #include "catalyst/utils/yaml/ryml_utils.hpp"
 
 namespace catalyst::fetch {
@@ -165,31 +166,6 @@ Result<void> fetchConanDeps(const std::vector<ryml::ConstNodeRef> &conan_deps,
 
 namespace {
 
-Result<void> fetchVcpkg(const std::string &name,
-                        const std::string &triplet,
-                        [[maybe_unused]] const catalyst::toolchain::ToolchainDef &tc) {
-    catalyst::logger.debug("Fetching vcpkg dependency: {} with triplet: {}", name, triplet);
-    char *vcpkg_root_env = std::getenv("VCPKG_ROOT");
-    if (vcpkg_root_env == nullptr) {
-        return std::unexpected(
-            "VCPKG_ROOT environment variable not set. Please set it to your vcpkg installation directory.");
-    }
-    fs::path vcpkg_root(vcpkg_root_env);
-    fs::path vcpkg_exe = vcpkg_root / "vcpkg";
-#if defined(_WIN32)
-    std::string exe_ext = tc.extensions.executable.empty() ? ".exe" : tc.extensions.executable;
-    vcpkg_exe.replace_extension(exe_ext);
-#endif
-    std::string target = name + ":" + triplet;
-    std::string command = std::format("\"{}\" install {}", vcpkg_exe.string(), target);
-    catalyst::logger.debug("Executing command: {}", command);
-    catalyst::logger.debug("Fetching: {} from vcpkg", target);
-    if (catalyst::processExec({vcpkg_exe.string(), "install", target}).value().get() != 0) {
-        return std::unexpected(std::format("Failed to fetch dependency: {}", target));
-    }
-    return {};
-}
-
 Result<void> fetchGit(
     const std::string &build_dir, std::string name, std::string source, std::string version, std::string hash = "") {
     catalyst::logger.debug("Fetching git dependency: {}@{} (hash: {}) from {}", name, version, hash, source);
@@ -320,13 +296,13 @@ struct LockedDep {
     std::string version;
     std::string triplet;
     std::string path;
+    std::optional<int> port_version;
 };
 
 Result<void> fetchDependency(ryml::ConstNodeRef dep,
                              const std::string &build_dir,
                              const std::unordered_map<std::string, LockedDep> &lockfile_deps,
-                             const Parse &parse_args,
-                             const catalyst::toolchain::ToolchainDef &tc) {
+                             const Parse &parse_args) {
     namespace yaml = utils::yaml;
     auto name = yaml::asString(yaml::child(dep, "name")).value_or("");
     auto source = yaml::asString(yaml::child(dep, "source")).value_or("");
@@ -365,38 +341,16 @@ Result<void> fetchDependency(ryml::ConstNodeRef dep,
     std::string locked_hash;
     std::string locked_url;
     std::string locked_version;
-    std::string locked_triplet;
     std::string locked_path;
     if (lockfile_deps.contains(name)) {
         locked_hash = lockfile_deps.at(name).hash;
         locked_url = lockfile_deps.at(name).url;
         locked_version = lockfile_deps.at(name).version;
-        locked_triplet = lockfile_deps.at(name).triplet;
         locked_path = lockfile_deps.at(name).path;
         catalyst::logger.debug("Dependency '{}' is locked.", name);
     }
 
-    if (source == "vcpkg") {
-        std::string version;
-        if (!locked_version.empty())
-            version = locked_version;
-        else if (auto v = yaml::asString(yaml::child(dep, "version")))
-            version = *v;
-        else
-            return std::unexpected(std::format("vcpkg dependency '{}' is missing version.", name));
-
-        std::string triplet;
-        if (!locked_triplet.empty())
-            triplet = locked_triplet;
-        else if (auto t = yaml::asString(yaml::child(dep, "triplet")))
-            triplet = *t;
-        else
-            return std::unexpected(std::format("vcpkg dependency '{}' is missing triplet.", name));
-
-        if (auto res = fetchVcpkg(name, triplet, tc); !res)
-            return std::unexpected(res.error());
-
-    } else if (source == "system") {
+    if (source == "system") {
         if (auto res = fetchSystem(name); !res)
             return std::unexpected(res.error());
     } else if (source == "custom") {
@@ -450,14 +404,6 @@ Result<void> action(const Parse &parse_args) {
     catalyst::logger.debug("Composing profiles.");
     utils::yaml::Configuration config{parse_args.profiles};
 
-    // Resolve active toolchain to get extensions
-    catalyst::toolchain::ToolchainDef tc;
-    if (auto toolchain_path = config.getString("manifest.toolchain")) {
-        if (auto parsed = catalyst::toolchain::parseToolchain(*toolchain_path)) {
-            tc = std::move(*parsed);
-        }
-    }
-
     catalyst::logger.debug("Running pre-fetch hooks.");
     if (auto res = hooks::preFetch(config); !res) {
         return res;
@@ -465,6 +411,7 @@ Result<void> action(const Parse &parse_args) {
 
     // Load lockfile if it exists
     std::unordered_map<std::string, LockedDep> lockfile_deps;
+    std::optional<std::string> locked_vcpkg_baseline;
     fs::path lockfile_path = "catalyst.lock";
     if (parse_args.workspace) {
         lockfile_path = parse_args.workspace->getRoot() / "catalyst.lock";
@@ -478,6 +425,8 @@ Result<void> action(const Parse &parse_args) {
             catalyst::logger.warn("Failed to load lockfile: {}", lock_tree.error());
         } else if (ryml::ConstNodeRef lock_deps = yaml::child(lock_tree->crootref(), "dependencies");
                    lock_deps.readable() && lock_deps.is_seq()) {
+            locked_vcpkg_baseline =
+                yaml::asString(yaml::child(yaml::child(lock_tree->crootref(), "vcpkg"), "builtin_baseline"));
             for (ryml::ConstNodeRef dep : lock_deps.children()) {
                 auto dep_name = yaml::asString(yaml::child(dep, "name"));
                 if (!dep_name)
@@ -488,6 +437,7 @@ Result<void> action(const Parse &parse_args) {
                 ld.version = yaml::asString(yaml::child(dep, "version")).value_or("");
                 ld.triplet = yaml::asString(yaml::child(dep, "triplet")).value_or("");
                 ld.path = yaml::asString(yaml::child(dep, "path")).value_or("");
+                ld.port_version = yaml::asInt(yaml::child(dep, "port_version"));
                 lockfile_deps[*dep_name] = ld;
             }
         }
@@ -499,6 +449,7 @@ Result<void> action(const Parse &parse_args) {
         std::vector<ryml::ConstNodeRef> parallel_deps;
         std::vector<ryml::ConstNodeRef> serial_deps;
         std::vector<ryml::ConstNodeRef> conan_deps;
+        std::vector<utils::vcpkg::Dependency> vcpkg_deps;
         std::unordered_set<std::string> seen_deps;
 
         for (int ii = 0; ryml::ConstNodeRef dep : deps.children()) {
@@ -524,11 +475,32 @@ Result<void> action(const Parse &parse_args) {
             std::string source = *source_opt;
             bool is_workspace_member = parse_args.workspace && parse_args.workspace->findPackage(name).has_value();
 
+            if (source == "vcpkg") {
+                const auto locked = lockfile_deps.find(name);
+                const std::string version = locked != lockfile_deps.end() && !locked->second.version.empty()
+                                                ? locked->second.version
+                                                : yaml::asString(yaml::child(dep, "version")).value_or("latest");
+                const std::string triplet = locked != lockfile_deps.end() && !locked->second.triplet.empty()
+                                                ? locked->second.triplet
+                                                : yaml::asString(yaml::child(dep, "triplet")).value_or("");
+                if (triplet.empty()) {
+                    return std::unexpected(std::format("vcpkg dependency '{}' is missing triplet.", name));
+                }
+                vcpkg_deps.push_back(
+                    {.name = name,
+                     .version = version,
+                     .triplet = triplet,
+                     .features = yaml::asStringVector(yaml::child(dep, "using")).value_or(std::vector<std::string>{}),
+                     .port_version = locked != lockfile_deps.end() ? locked->second.port_version : std::nullopt});
+                ++ii;
+                continue;
+            }
+
             // 2. Categorize by safety
             // Workspace links, vcpkg installs, and local builds mutate shared state
             if (source == "conan") {
                 conan_deps.push_back(dep);
-            } else if (is_workspace_member || source == "vcpkg" || source == "local") {
+            } else if (is_workspace_member || source == "local") {
                 serial_deps.push_back(dep);
             } else {
                 parallel_deps.push_back(dep);
@@ -536,13 +508,21 @@ Result<void> action(const Parse &parse_args) {
             ++ii;
         }
 
+        if (!vcpkg_deps.empty()) {
+            catalyst::logger.info("Installing vcpkg dependencies in manifest mode.");
+            auto installed = utils::vcpkg::install(vcpkg_deps, build_dir, locked_vcpkg_baseline);
+            if (!installed) {
+                return std::unexpected(installed.error());
+            }
+        }
+
         // 3. Execute parallel-safe (git, system)
         if (!parallel_deps.empty()) {
             std::vector<std::future<Result<void>>> futures;
             for (auto dep : parallel_deps) {
                 // Launch fetch in parallel
-                futures.push_back(std::async(std::launch::async, [dep, build_dir, &lockfile_deps, &parse_args, tc]() {
-                    return fetchDependency(dep, build_dir, lockfile_deps, parse_args, tc);
+                futures.push_back(std::async(std::launch::async, [dep, build_dir, &lockfile_deps, &parse_args]() {
+                    return fetchDependency(dep, build_dir, lockfile_deps, parse_args);
                 }));
             }
 
@@ -566,7 +546,7 @@ Result<void> action(const Parse &parse_args) {
         // 4. Execute serial-only (vcpkg, local, workspace link)
         // Maintain fail-fast semantics for these
         for (auto dep : serial_deps) {
-            if (auto res = fetchDependency(dep, build_dir, lockfile_deps, parse_args, tc); !res) {
+            if (auto res = fetchDependency(dep, build_dir, lockfile_deps, parse_args); !res) {
                 return res; // Fail fast
             }
         }

--- a/src/subcommands/fmt/parse_cli.cpp
+++ b/src/subcommands/fmt/parse_cli.cpp
@@ -1,5 +1,9 @@
 #include "catalyst/subcommands/fmt.hpp"
 
 auto catalyst::fmt::parse(CLI::App &app) -> std::pair<CLI::App *, std::unique_ptr<Parse>> {
-    return {app.add_subcommand("fmt", "Format project source files."), std::make_unique<Parse>()};
+    CLI::App *fmt = app.add_subcommand("fmt", "Format project source files.");
+    auto ret = std::make_unique<Parse>();
+    fmt->add_option("-p,--profiles", ret->profiles, "Profile composition to build.")
+        ->default_val(std::vector{"common"});
+    return {fmt, std::move(ret)};
 }

--- a/src/subcommands/generate/action.cpp
+++ b/src/subcommands/generate/action.cpp
@@ -331,29 +331,6 @@ std::string writeVariables(const catalyst::utils::yaml::Configuration &config,
     std::string ldflags =
         tc.linker.flags + " " + catalyst::toolchain::expandTemplate(tc.flags.lib_dir, {{"path", "catalyst-libs"}});
 
-    if (const char *vcpkg_root = std::getenv("VCPKG_ROOT"); vcpkg_root != nullptr) {
-#if defined(_WIN32)
-        const char *triplet = "x64-windows";
-#elif defined(__APPLE__)
-        const char *triplet = "x64-osx";
-#else
-        const char *triplet = "x64-linux";
-#endif
-        cxxflags +=
-            " "
-            + catalyst::toolchain::expandTemplate(
-                tc.flags.include_dir, {{"path", (fs::path(vcpkg_root) / "installed" / triplet / "include").string()}});
-        ccflags +=
-            " "
-            + catalyst::toolchain::expandTemplate(
-                tc.flags.include_dir, {{"path", (fs::path(vcpkg_root) / "installed" / triplet / "include").string()}});
-        ldflags += " "
-                   + catalyst::toolchain::expandTemplate(
-                       tc.flags.lib_dir, {{"path", (fs::path(vcpkg_root) / "installed" / triplet / "lib").string()}});
-    } else {
-        logger.warn("VCPKG_ROOT environment variable is not defined.");
-    }
-
     std::string proj_name = config.getString("manifest.name").value_or("name");
     for (const auto &ff : features) {
         if (ff.type == "bool") {

--- a/src/subcommands/generate/action.cpp
+++ b/src/subcommands/generate/action.cpp
@@ -5,6 +5,7 @@
 #include <expected>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
@@ -19,6 +20,14 @@
 
 namespace catalyst::generate {
 namespace fs = std::filesystem;
+
+std::string buildFilename(std::string_view generator) {
+    if (generator == "ninja")
+        return "build.ninja";
+    if (generator == "gmake" || generator == "make")
+        return "Makefile";
+    return "catalyst.build";
+}
 
 namespace {
 
@@ -70,9 +79,10 @@ Result<void> action(const Parse &parse_args) {
     }
     const std::vector<FeatureFlag> &features = *features_res;
 
-    catalyst::logger.debug("Running pre-generate hooks.");
-    if (auto res = hooks::preGenerate(config); !res) {
-        return res;
+    if (!parse_args.skip_pre_generate) {
+        catalyst::logger.debug("Running pre-generate hooks.");
+        if (auto res = hooks::preGenerate(config); !res)
+            return res;
     }
 
     fs::path current_dir = fs::current_path();
@@ -110,30 +120,21 @@ Result<void> action(const Parse &parse_args) {
         generator = config.getString("meta.generator").value_or("cob");
     }
 
-    std::string build_filename;
-    if (generator == "ninja") {
-        build_filename = "build.ninja";
-    } else if (generator == "gmake" || generator == "make") {
-        build_filename = "Makefile";
-    } else {
-        build_filename = "catalyst.build";
-    }
+    const std::string build_filename = buildFilename(generator);
 
     const fs::path buildfile_path = build_dir / build_filename;
+    std::optional<fs::path> toolchain_path;
+    if (auto configured_path = config.getString("manifest.toolchain"))
+        toolchain_path = *configured_path;
+    auto resolved_toolchain = catalyst::toolchain::resolveToolchain(toolchain_path);
+    if (!resolved_toolchain)
+        return std::unexpected(resolved_toolchain.error());
+    catalyst::toolchain::ToolchainDef tc = std::move(*resolved_toolchain);
+
     catalyst::logger.debug("Writing build file to: {}", buildfile_path.string());
     std::ofstream buildfile{buildfile_path};
-
     if (!buildfile) {
         return std::unexpected(std::format("Failed to open {} for writing", buildfile_path.string()));
-    }
-
-    catalyst::toolchain::ToolchainDef tc;
-    if (auto toolchain_path = config.getString("manifest.toolchain")) {
-        auto parsed = catalyst::toolchain::parseToolchain(*toolchain_path);
-        if (!parsed) {
-            return std::unexpected(std::format("Failed to load toolchain {}: {}", *toolchain_path, parsed.error()));
-        }
-        tc = std::move(*parsed);
     }
 
     auto generate_build = [&](buildwriters::BaseWriter &writer) -> Result<void> {
@@ -166,6 +167,10 @@ Result<void> action(const Parse &parse_args) {
     if (!generate_res) {
         return generate_res;
     }
+    buildfile.close();
+    if (!buildfile) {
+        return std::unexpected(std::format("Failed to write {}", buildfile_path.string()));
+    }
 
     catalyst::logger.debug("Writing profile composition to: {}", (build_dir / "profile_composition.yaml").string());
     std::ofstream profile_comp_file{build_dir / "profile_composition.yaml"};
@@ -177,6 +182,18 @@ Result<void> action(const Parse &parse_args) {
     catalyst::logger.debug("Running post-generate hooks.");
     if (auto res = hooks::postGenerate(config); !res) {
         return res;
+    }
+
+    const fs::path toolchain_store_path = build_dir / catalyst::toolchain::RESOLVED_TOOLCHAIN_STORE_FILENAME;
+    catalyst::logger.debug("Writing resolved toolchain to: {}", toolchain_store_path.string());
+    std::ofstream toolchain_store{toolchain_store_path, std::ios::binary | std::ios::trunc};
+    if (!toolchain_store) {
+        return std::unexpected(std::format("Failed to open {} for writing", toolchain_store_path.string()));
+    }
+    toolchain_store << catalyst::toolchain::serializeToolchainStore(tc, generator);
+    toolchain_store.close();
+    if (!toolchain_store) {
+        return std::unexpected(std::format("Failed to write {}", toolchain_store_path.string()));
     }
     catalyst::logger.debug("Generate subcommand finished successfully.");
     return {};
@@ -238,11 +255,12 @@ Result<std::vector<std::string>> intermediateTargets(catalyst::generate::buildwr
             }
         }
 
-        void(writer.addBuild({object_files.back()},
-                             (std::ranges::contains(tc.extensions.c_sources, src.extension().string()) ? "cc_compile" : "cxx_compile"),
-                             {src.string()},
-                             implicit_deps,
-                             extra_args));
+        void(writer.addBuild(
+            {object_files.back()},
+            (std::ranges::contains(tc.extensions.c_sources, src.extension().string()) ? "cc_compile" : "cxx_compile"),
+            {src.string()},
+            implicit_deps,
+            extra_args));
     }
     return object_files;
 }

--- a/src/subcommands/generate/find_dep.cpp
+++ b/src/subcommands/generate/find_dep.cpp
@@ -23,7 +23,7 @@ auto catalyst::generate::findDep(const std::string &build_dir,
         return findSystem(dep, tc);
     }
     if (*source_type == "vcpkg") {
-        return findVcpkg(dep, tc);
+        return findVcpkg(build_dir, dep, tc);
     }
     if (*source_type == "git") {
         return findGit(build_dir, dep, tc);

--- a/src/subcommands/generate/find_dep/vcpkg.cpp
+++ b/src/subcommands/generate/find_dep/vcpkg.cpp
@@ -81,13 +81,54 @@ std::string normalizeDepToken(std::string_view token) {
     return std::string(trim(token));
 }
 
-// True when the package has a real installed footprint for @p triplet (a lib/
-// or include/ directory), as opposed to a build-time helper port (e.g.
-// vcpkg-cmake) that only ships cmake scripts under share/.
-bool packageHasArtifacts(const fs::path &vcpkg_root, const std::string &name, const std::string &triplet) {
-    fs::path base = vcpkg_root / "packages" / std::format("{}_{}", name, triplet);
+std::optional<fs::path>
+packageInfoList(const fs::path &installed_root, const std::string &name, const std::string &triplet) {
+    const fs::path info_dir = installed_root / "vcpkg" / "info";
     std::error_code ec;
-    return fs::is_directory(base / "lib", ec) || fs::is_directory(base / "include", ec);
+    if (!fs::is_directory(info_dir, ec)) {
+        return std::nullopt;
+    }
+
+    const std::string prefix = name + "_";
+    const std::string suffix = "_" + triplet + ".list";
+    for (const fs::directory_entry &entry : fs::directory_iterator(info_dir, ec)) {
+        const std::string filename = entry.path().filename().string();
+        if (entry.is_regular_file(ec) && filename.starts_with(prefix) && filename.ends_with(suffix)) {
+            return entry.path();
+        }
+    }
+    return std::nullopt;
+}
+
+std::vector<fs::path>
+packageFiles(const fs::path &installed_root, const std::string &name, const std::string &triplet) {
+    std::vector<fs::path> result;
+    const auto list_path = packageInfoList(installed_root, name, triplet);
+    if (!list_path) {
+        return result;
+    }
+
+    std::ifstream input(*list_path);
+    for (std::string relative_path; std::getline(input, relative_path);) {
+        if (!relative_path.empty() && !relative_path.ends_with('/')) {
+            result.push_back(installed_root / relative_path);
+        }
+    }
+    return result;
+}
+
+// True when the package has a real installed footprint for @p triplet, as
+// opposed to a build-time helper port that only ships metadata under share/.
+bool packageHasArtifacts(const fs::path &installed_root, const std::string &name, const std::string &triplet) {
+    const std::string include_prefix = triplet + "/include/";
+    const std::string lib_prefix = triplet + "/lib/";
+    for (const fs::path &path : packageFiles(installed_root, name, triplet)) {
+        const std::string relative = fs::relative(path, installed_root).generic_string();
+        if (relative.starts_with(include_prefix) || relative.starts_with(lib_prefix)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 // The library-file extensions a vcpkg package may ship, derived from the
@@ -110,19 +151,25 @@ std::string strippedLibStem(std::string stem, const catalyst::toolchain::Toolcha
     return stem;
 }
 
-// Scans @p lib_path for library files and appends a toolchain library token for
-// each to @p libs. @p lib_path must exist and be a directory.
-void appendScannedLibs(std::string &libs, const fs::path &lib_path, const catalyst::toolchain::ToolchainDef &tc) {
+// Appends library files owned by one installed package. The vcpkg info list is
+// used instead of scanning the shared triplet lib directory, which also
+// contains artifacts from unrelated packages.
+void appendScannedLibs(std::string &libs,
+                       const fs::path &installed_root,
+                       const std::string &name,
+                       const std::string &triplet,
+                       const catalyst::toolchain::ToolchainDef &tc) {
     std::vector<std::string> extensions = libExtensions(tc);
-    for (const auto &entry : fs::directory_iterator(lib_path)) {
-        if (!entry.is_regular_file()) {
+    const fs::path release_lib_dir = installed_root / triplet / "lib";
+    for (const fs::path &path : packageFiles(installed_root, name, triplet)) {
+        if (path.parent_path() != release_lib_dir) {
             continue;
         }
-        std::string file_ext = entry.path().extension().string();
+        std::string file_ext = path.extension().string();
         if (std::ranges::find(extensions, file_ext) == extensions.end()) {
             continue;
         }
-        std::string stem = strippedLibStem(entry.path().stem().string(), tc);
+        std::string stem = strippedLibStem(path.stem().string(), tc);
         libs += " " + catalyst::toolchain::expandTemplate(tc.flags.lib, {{"name", stem}});
         catalyst::logger.debug("Found and added library: {}", stem);
     }
@@ -134,19 +181,24 @@ void appendScannedLibs(std::string &libs, const fs::path &lib_path, const cataly
 // @p fabricate_if_missing controls whether a bare `-l<name>` is emitted when the
 // package has no lib/ directory at all (used only for an explicitly requested
 // dependency, never for auto-discovered transitive ones).
-FindRes resolveVcpkgPackage(const fs::path &vcpkg_root,
-                            const std::string &name,
-                            const std::string &triplet,
-                            const std::string &linkage,
-                            const catalyst::toolchain::ToolchainDef &tc,
-                            bool fabricate_if_missing) {
-    fs::path package_dir_name = std::format("{}_{}", name, triplet);
-    fs::path lib_path = vcpkg_root / "packages" / package_dir_name / "lib";
+struct ResolvedVcpkgPackage {
+    FindRes flags;
+    bool pkg_config_expanded_dependencies = false;
+};
+
+ResolvedVcpkgPackage resolveVcpkgPackage(const fs::path &installed_root,
+                                         const std::string &name,
+                                         const std::string &triplet,
+                                         const std::string &linkage,
+                                         const catalyst::toolchain::ToolchainDef &tc,
+                                         bool fabricate_if_missing,
+                                         bool use_pkg_config) {
+    fs::path lib_path = installed_root / triplet / "lib";
 
     fs::path pkg_config_dir = lib_path / "pkgconfig";
     fs::path pc_file = pkg_config_dir / std::format("{}.pc", name);
 
-    if (fs::exists(pc_file)) {
+    if (use_pkg_config && fs::exists(pc_file)) {
         catalyst::logger.debug("Found pkg-config file for {}: {}", name, pc_file.string());
 
         std::unordered_map<std::string, std::string> env;
@@ -171,7 +223,7 @@ FindRes resolveVcpkgPackage(const fs::path &vcpkg_root,
             catalyst::logger.debug("Resolved via pkg-config: L='{}' l='{}'", link_dirs, link_libs);
             FindRes result{.lib_path = "", .inc_path = "", .libs = "", .lib_dirs = {}};
             appendPkgConfigLibs(result, link_dirs, link_libs, tc);
-            return result;
+            return {.flags = std::move(result), .pkg_config_expanded_dependencies = true};
         }
         catalyst::logger.warn("pkg-config failed for {}, falling back.", name);
     }
@@ -181,10 +233,10 @@ FindRes resolveVcpkgPackage(const fs::path &vcpkg_root,
     std::string libs;
     std::vector<std::string> lib_dirs;
 
-    bool lib_dir_exists = fs::exists(lib_path) && fs::is_directory(lib_path);
-    if ((linkage == "static" || linkage == "shared") && !lib_dir_exists) {
+    const bool has_artifacts = packageHasArtifacts(installed_root, name, triplet);
+    if ((linkage == "static" || linkage == "shared") && !has_artifacts) {
         catalyst::logger.warn(
-            "Could not find library directory for vcpkg package '{}' at: {}", name, lib_path.string());
+            "Could not find installed artifacts for vcpkg package '{}' under: {}", name, installed_root.string());
         if (fabricate_if_missing) {
             libs += " " + catalyst::toolchain::expandTemplate(tc.flags.lib, {{"name", name}});
         }
@@ -194,14 +246,12 @@ FindRes resolveVcpkgPackage(const fs::path &vcpkg_root,
     catalyst::logger.debug("Adding library path: {}", lib_path.string());
     lib_dirs.push_back(lib_path.string());
 
-    if ((linkage == "static" || linkage == "shared") && lib_dir_exists) {
-        appendScannedLibs(libs, lib_path, tc);
+    if ((linkage == "static" || linkage == "shared") && has_artifacts) {
+        appendScannedLibs(libs, installed_root, name, triplet, tc);
     }
 
-    return FindRes{.lib_path = library_path,
-                   .inc_path = "", // already set in write_variables
-                   .libs = libs,
-                   .lib_dirs = lib_dirs};
+    return {.flags = {.lib_path = library_path, .inc_path = "", .libs = libs, .lib_dirs = lib_dirs},
+            .pkg_config_expanded_dependencies = false};
 }
 } // namespace
 
@@ -307,7 +357,8 @@ vcpkgTransitiveClosure(const VcpkgStatusDb &db,
     return ordered;
 }
 
-Result<FindRes> findVcpkg(ryml::ConstNodeRef dep, const catalyst::toolchain::ToolchainDef &tc) {
+Result<FindRes>
+findVcpkg(const std::string &build_dir, ryml::ConstNodeRef dep, const catalyst::toolchain::ToolchainDef &tc) {
     namespace yaml = catalyst::utils::yaml;
     std::string dep_name = yaml::asString(yaml::child(dep, "name")).value_or("<unnamed>");
     auto triplet_opt = yaml::asString(yaml::child(dep, "triplet"));
@@ -318,16 +369,33 @@ Result<FindRes> findVcpkg(ryml::ConstNodeRef dep, const catalyst::toolchain::Too
     std::string linkage = yaml::asString(yaml::child(dep, "linkage")).value_or("shared");
     bool transitive = yaml::asBool(yaml::child(dep, "transitive")).value_or(true);
 
-    const char *vcpkg_root_env = std::getenv("VCPKG_ROOT");
-    if (vcpkg_root_env == nullptr) {
-        return std::unexpected(std::format("VCPKG_ROOT is not set, cannot resolve vcpkg dependency '{}'.", dep_name));
+    fs::path installed_root = fs::absolute(fs::path(build_dir) / "vcpkg_installed");
+    if (!fs::is_directory(installed_root)) {
+        const char *vcpkg_root_env = std::getenv("VCPKG_ROOT");
+        if (vcpkg_root_env == nullptr) {
+            return std::unexpected(
+                std::format("No manifest install exists and VCPKG_ROOT is not set for '{}'.", dep_name));
+        }
+        installed_root = fs::path(vcpkg_root_env) / "installed";
+        catalyst::logger.warn("Using the legacy global vcpkg installed tree for '{}'. Run 'catalyst fetch' to create "
+                              "the profile-local manifest installation.",
+                              dep_name);
     }
-    fs::path vcpkg_root(vcpkg_root_env);
 
     catalyst::logger.debug("Resolving vcpkg dependency: {}", dep_name);
-    FindRes result = resolveVcpkgPackage(vcpkg_root, dep_name, triplet, linkage, tc, /*fabricate_if_missing=*/true);
+    ResolvedVcpkgPackage root = resolveVcpkgPackage(installed_root,
+                                                    dep_name,
+                                                    triplet,
+                                                    linkage,
+                                                    tc,
+                                                    /*fabricate_if_missing=*/true,
+                                                    /*use_pkg_config=*/transitive);
+    FindRes result = std::move(root.flags);
+    result.inc_path += " "
+                       + catalyst::toolchain::expandTemplate(
+                           tc.flags.include_dir, {{"path", (installed_root / triplet / "include").string()}});
 
-    if (!transitive) {
+    if (!transitive || root.pkg_config_expanded_dependencies) {
         return result;
     }
 
@@ -337,7 +405,7 @@ Result<FindRes> findVcpkg(ryml::ConstNodeRef dep, const catalyst::toolchain::Too
     // transitive package by hand. Build-time helper ports are pruned by the
     // packageHasArtifacts predicate, and packages are emitted parent-before-child
     // so static link order stays correct.
-    fs::path status_path = vcpkg_root / "installed" / "vcpkg" / "status";
+    fs::path status_path = installed_root / "vcpkg" / "status";
     auto status_content = readFileToString(status_path);
     if (!status_content) {
         catalyst::logger.warn("Could not read vcpkg status database at {}; skipping transitive resolution for '{}'.",
@@ -347,16 +415,22 @@ Result<FindRes> findVcpkg(ryml::ConstNodeRef dep, const catalyst::toolchain::Too
     }
 
     VcpkgStatusDb db = parseVcpkgStatus(*status_content);
-    auto is_real_port = [&vcpkg_root](const std::string &name, const std::string &tr) {
-        return packageHasArtifacts(vcpkg_root, name, tr);
+    auto is_real_port = [&installed_root](const std::string &name, const std::string &tr) {
+        return packageHasArtifacts(installed_root, name, tr);
     };
 
     for (const std::string &tdep : vcpkgTransitiveClosure(db, dep_name, triplet, is_real_port)) {
         catalyst::logger.debug("Resolving transitive vcpkg dependency of {}: {}", dep_name, tdep);
-        FindRes tres = resolveVcpkgPackage(vcpkg_root, tdep, triplet, linkage, tc, /*fabricate_if_missing=*/false);
-        result.lib_path += tres.lib_path;
-        result.libs += tres.libs;
-        result.lib_dirs.insert(result.lib_dirs.end(), tres.lib_dirs.begin(), tres.lib_dirs.end());
+        ResolvedVcpkgPackage resolved = resolveVcpkgPackage(installed_root,
+                                                            tdep,
+                                                            triplet,
+                                                            linkage,
+                                                            tc,
+                                                            /*fabricate_if_missing=*/false,
+                                                            /*use_pkg_config=*/false);
+        result.lib_path += resolved.flags.lib_path;
+        result.libs += resolved.flags.libs;
+        result.lib_dirs.insert(result.lib_dirs.end(), resolved.flags.lib_dirs.begin(), resolved.flags.lib_dirs.end());
     }
 
     return result;

--- a/src/subcommands/generate/ldlibs.cpp
+++ b/src/subcommands/generate/ldlibs.cpp
@@ -10,13 +10,10 @@
 #include "catalyst/utils/yaml/ryml_utils.hpp"
 
 #ifdef _WIN32
-constexpr const char *const TRIPLET = "x64-windows";
 constexpr char DELIMITER = ';';
 #elif defined(__APPLE__)
-constexpr const char *const TRIPLET = "x64-osx";
 constexpr char DELIMITER = ':';
 #else
-constexpr const char *const TRIPLET = "x64-linux";
 constexpr char DELIMITER = ':';
 #endif
 
@@ -28,11 +25,6 @@ auto catalyst::generate::libPath(const utils::yaml::Configuration &profile_comp,
     std::filesystem::path build_dir = catalyst::utils::yaml::multiplexedBuildDir(
         profile_comp.getString("manifest.dirs.build").value_or(""), profiles);
     std::vector<std::string> lib_dirs{std::filesystem::absolute("catalyst-libs").string()};
-
-    if (const char *vcpkg_root = std::getenv("VCPKG_ROOT"); vcpkg_root)
-        lib_dirs.push_back((std::filesystem::path(vcpkg_root) / "installed" / TRIPLET / "lib").string());
-    else
-        logger.warn("VCPKG_ROOT environment variable is not defined.");
 
     if (auto deps = yaml::child(profile_comp.rootRef(), "dependencies"); deps.readable() && deps.is_seq())
         for (ryml::ConstNodeRef dep : deps.children()) {

--- a/src/subcommands/lock/action.cpp
+++ b/src/subcommands/lock/action.cpp
@@ -2,6 +2,7 @@
 #include <format>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <print>
 #include <string>
 #include <unordered_map>
@@ -11,6 +12,7 @@
 #include "catalyst/subcommands/lock.hpp"
 #include "catalyst/utils/log/log.hpp"
 #include "catalyst/utils/result.hpp"
+#include "catalyst/utils/vcpkg.hpp"
 #include "catalyst/utils/yaml/configuration.hpp"
 #include "catalyst/utils/yaml/ryml_utils.hpp"
 
@@ -70,6 +72,8 @@ struct DependencyInfo {
     std::string hash;
     std::string triplet;
     std::string path;
+    std::vector<std::string> features;
+    int port_version = 0;
 
     bool operator==(const DependencyInfo &other) const {
         return name == other.name;
@@ -105,8 +109,9 @@ void collectDependencies(const utils::yaml::Configuration &config,
             info.url = yaml::asString(yaml::child(dep, "url")).value_or(info.source);
             info.version = yaml::asString(yaml::child(dep, "version")).value_or("latest");
         } else if (info.source == "vcpkg") {
-            info.version = yaml::asString(yaml::child(dep, "version")).value_or("");
+            info.version = yaml::asString(yaml::child(dep, "version")).value_or("latest");
             info.triplet = yaml::asString(yaml::child(dep, "triplet")).value_or("");
+            info.features = yaml::asStringVector(yaml::child(dep, "using")).value_or(std::vector<std::string>{});
         } else if (info.source == "local") {
             info.path = yaml::asString(yaml::child(dep, "path")).value_or("");
         }
@@ -122,10 +127,12 @@ Result<void> action(const Parse &parse_args) {
 
     std::unordered_map<std::string, DependencyInfo> locked_deps;
     fs::path lockfile_path = "catalyst.lock";
+    fs::path vcpkg_build_dir;
 
     if (parse_args.workspace) {
         catalyst::logger.info("Resolving dependencies for workspace...");
         lockfile_path = parse_args.workspace->getRoot() / "catalyst.lock";
+        vcpkg_build_dir = parse_args.workspace->getRoot() / "build" / "catalyst-lock";
 
         // Load configurations in parallel, then collect dependencies sequentially
         // for deterministic resolution order
@@ -164,15 +171,57 @@ Result<void> action(const Parse &parse_args) {
     } else {
         utils::yaml::Configuration config(parse_args.profiles);
         collectDependencies(config, locked_deps, std::nullopt);
+        vcpkg_build_dir = config.getBuildDir() / "catalyst-lock";
     }
 
     std::println(std::cout, "Locking {} dependencies...", locked_deps.size());
+
+    std::vector<utils::vcpkg::Dependency> vcpkg_dependencies;
+    for (const auto &[name, info] : locked_deps) {
+        if (info.source == "vcpkg") {
+            if (info.triplet.empty()) {
+                return std::unexpected(std::format("vcpkg dependency '{}' is missing triplet.", name));
+            }
+            vcpkg_dependencies.push_back({.name = name,
+                                          .version = info.version,
+                                          .triplet = info.triplet,
+                                          .features = info.features,
+                                          .port_version = std::nullopt});
+        }
+    }
+
+    std::optional<utils::vcpkg::InstallResult> vcpkg_install;
+    if (!vcpkg_dependencies.empty()) {
+        catalyst::logger.info("Resolving vcpkg dependencies in manifest mode.");
+        auto installed = utils::vcpkg::install(vcpkg_dependencies, vcpkg_build_dir);
+        if (!installed) {
+            return std::unexpected(installed.error());
+        }
+        vcpkg_install = std::move(*installed);
+        for (auto &[name, info] : locked_deps) {
+            if (info.source != "vcpkg") {
+                continue;
+            }
+            const auto resolved = vcpkg_install->packages.find(utils::vcpkg::statusKey(name, info.triplet));
+            if (resolved == vcpkg_install->packages.end()) {
+                return std::unexpected(
+                    std::format("vcpkg did not report an installed version for '{}:{}'", name, info.triplet));
+            }
+            info.version = resolved->second.version;
+            info.port_version = resolved->second.port_version;
+        }
+    }
 
     namespace yaml = utils::yaml;
     ryml::Tree lock_tree;
     ryml::NodeRef lock_root = lock_tree.rootref();
     lock_root |= ryml::MAP;
-    lock_root["lockfile_version"] = "1.0.0";
+    lock_root["lockfile_version"] = "1.1.0";
+    if (vcpkg_install) {
+        ryml::NodeRef vcpkg_node = yaml::childOrCreate(lock_root, "vcpkg");
+        vcpkg_node |= ryml::MAP;
+        vcpkg_node["builtin_baseline"] = lock_tree.to_arena(vcpkg_install->builtin_baseline);
+    }
     ryml::NodeRef deps_node = yaml::childOrCreate(lock_root, "dependencies");
     deps_node |= ryml::SEQ;
 
@@ -199,6 +248,8 @@ Result<void> action(const Parse &parse_args) {
             dep_node["hash"] = lock_tree.to_arena(info.hash);
         if (!info.triplet.empty())
             dep_node["triplet"] = lock_tree.to_arena(info.triplet);
+        if (info.source == "vcpkg")
+            dep_node["port_version"] = lock_tree.to_arena(std::to_string(info.port_version));
         if (!info.path.empty())
             dep_node["path"] = lock_tree.to_arena(info.path);
     }

--- a/src/utils/toolchain.cpp
+++ b/src/utils/toolchain.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <format>
 #include <ranges>
+#include <sstream>
 #include <vector>
 
 #include "catalyst/utils/result.hpp"
@@ -13,6 +14,73 @@ static constexpr size_t TUNABLE_MAX_INHERITANCE_DEPTH = 32;
 namespace catalyst::toolchain {
 
 namespace {
+
+std::string yamlQuote(std::string_view value) {
+    constexpr char HEX_DIGITS[] = "0123456789ABCDEF";
+
+    std::string quoted;
+    quoted.reserve(value.size() + 2);
+    quoted.push_back('"');
+    for (unsigned char c : value) {
+        switch (c) {
+            case '"':
+                quoted += "\\\"";
+                break;
+            case '\\':
+                quoted += "\\\\";
+                break;
+            case '\n':
+                quoted += "\\n";
+                break;
+            case '\r':
+                quoted += "\\r";
+                break;
+            case '\t':
+                quoted += "\\t";
+                break;
+            default:
+                if (c < 0x20 || c == 0x7f) {
+                    quoted += "\\x";
+                    quoted.push_back(HEX_DIGITS[c >> 4]);
+                    quoted.push_back(HEX_DIGITS[c & 0x0f]);
+                } else {
+                    quoted.push_back(static_cast<char>(c));
+                }
+        }
+    }
+    quoted.push_back('"');
+    return quoted;
+}
+
+void writeScalar(std::ostringstream &out, size_t indentation, std::string_view key, std::string_view value) {
+    out << std::string(indentation, ' ') << key << ": " << yamlQuote(value) << '\n';
+}
+
+void writeSequence(std::ostringstream &out,
+                   size_t indentation,
+                   std::string_view key,
+                   const std::vector<std::string> &values) {
+    out << std::string(indentation, ' ') << key << ':';
+    if (values.empty()) {
+        out << " []\n";
+        return;
+    }
+    out << '\n';
+    for (const auto &value : values)
+        out << std::string(indentation + 2, ' ') << "- " << yamlQuote(value) << '\n';
+}
+
+void finalizeToolchain(ToolchainDef &toolchain) {
+    if (!toolchain.extensions.library_scan.empty())
+        return;
+#if defined(_WIN32)
+    toolchain.extensions.library_scan = {".lib"};
+#elif defined(__APPLE__)
+    toolchain.extensions.library_scan = {".a", ".dylib"};
+#else
+    toolchain.extensions.library_scan = {".a", ".so"};
+#endif
+}
 
 std::vector<std::string> splitTokens(std::string_view str) {
     auto is_space = [](char c) constexpr -> bool { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; };
@@ -223,16 +291,77 @@ Result<ToolchainDef> parseToolchain(const std::filesystem::path &path) {
     if (!res) {
         return std::unexpected(res.error());
     }
-    if (tc.extensions.library_scan.empty()) {
-#if defined(_WIN32)
-        tc.extensions.library_scan = {".lib"};
-#elif defined(__APPLE__)
-        tc.extensions.library_scan = {".a", ".dylib"};
-#else
-        tc.extensions.library_scan = {".a", ".so"};
-#endif
-    }
+    finalizeToolchain(tc);
     return tc;
+}
+
+Result<ToolchainDef> resolveToolchain(const std::optional<std::filesystem::path> &path) {
+    if (!path) {
+        ToolchainDef toolchain;
+        finalizeToolchain(toolchain);
+        return toolchain;
+    }
+
+    auto toolchain = parseToolchain(*path);
+    if (!toolchain) {
+        return std::unexpected(std::format("Failed to load toolchain {}: {}", path->string(), toolchain.error()));
+    }
+    return toolchain;
+}
+
+std::string serializeToolchain(const ToolchainDef &toolchain) {
+    std::ostringstream out;
+    out << "# Fully resolved Catalyst toolchain. Generated automatically.\n"
+           "toolchain:\n";
+    writeScalar(out, 2, "name", toolchain.name);
+
+    out << "  extensions:\n";
+    writeScalar(out, 4, "object", toolchain.extensions.object);
+    writeScalar(out, 4, "executable", toolchain.extensions.executable);
+    writeScalar(out, 4, "static_lib", toolchain.extensions.static_lib);
+    writeScalar(out, 4, "shared_lib", toolchain.extensions.shared_lib);
+    writeScalar(out, 4, "static_lib_prefix", toolchain.extensions.static_lib_prefix);
+    writeScalar(out, 4, "shared_lib_prefix", toolchain.extensions.shared_lib_prefix);
+    writeSequence(out, 4, "cpp_sources", toolchain.extensions.cpp_sources);
+    writeSequence(out, 4, "headers", toolchain.extensions.headers);
+    writeSequence(out, 4, "c_sources", toolchain.extensions.c_sources);
+    writeSequence(out, 4, "module_interfaces", toolchain.extensions.module_interfaces);
+    writeSequence(out, 4, "clang_modules", toolchain.extensions.clang_modules);
+    writeScalar(out, 4, "bmi", toolchain.extensions.bmi);
+    writeSequence(out, 4, "library_scan", toolchain.extensions.library_scan);
+    writeSequence(out, 4, "shell_scripts", toolchain.extensions.shell_scripts);
+
+    out << "  flags:\n";
+    writeScalar(out, 4, "include_dir", toolchain.flags.include_dir);
+    writeScalar(out, 4, "lib_dir", toolchain.flags.lib_dir);
+    writeScalar(out, 4, "lib", toolchain.flags.lib);
+    writeScalar(out, 4, "define", toolchain.flags.define);
+    writeScalar(out, 4, "define_empty", toolchain.flags.define_empty);
+
+    out << "  compiler:\n"
+           "    c:\n";
+    writeScalar(out, 6, "executable", toolchain.compiler.c.executable);
+    writeScalar(out, 6, "flags", toolchain.compiler.c.flags);
+    writeScalar(out, 6, "command", toolchain.compiler.c.command);
+    out << "    cxx:\n";
+    writeScalar(out, 6, "executable", toolchain.compiler.cxx.executable);
+    writeScalar(out, 6, "flags", toolchain.compiler.cxx.flags);
+    writeScalar(out, 6, "command", toolchain.compiler.cxx.command);
+
+    out << "  linker:\n";
+    writeScalar(out, 4, "executable", toolchain.linker.executable);
+    writeScalar(out, 4, "flags", toolchain.linker.flags);
+    writeScalar(out, 4, "executable_command", toolchain.linker.executable_command);
+    writeScalar(out, 4, "shared_lib_command", toolchain.linker.shared_lib_command);
+
+    out << "  archiver:\n";
+    writeScalar(out, 4, "executable", toolchain.archiver.executable);
+    writeScalar(out, 4, "command", toolchain.archiver.command);
+    return std::move(out).str();
+}
+
+std::string serializeToolchainStore(const ToolchainDef &toolchain, std::string_view generator) {
+    return "catalyst_generator: " + yamlQuote(generator) + '\n' + serializeToolchain(toolchain);
 }
 
 } // namespace catalyst::toolchain

--- a/src/utils/vcpkg.cpp
+++ b/src/utils/vcpkg.cpp
@@ -1,0 +1,321 @@
+#include "catalyst/utils/vcpkg.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <span>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "catalyst/process_exec.hpp"
+#include "catalyst/utils/result.hpp"
+
+namespace catalyst::utils::vcpkg {
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string trim(std::string value) {
+    const auto first = std::ranges::find_if_not(value, [](unsigned char c) { return std::isspace(c) != 0; });
+    value.erase(value.begin(), first);
+    const auto last =
+        std::ranges::find_if_not(value.rbegin(), value.rend(), [](unsigned char c) { return std::isspace(c) != 0; });
+    value.erase(last.base(), value.end());
+    return value;
+}
+
+std::string jsonString(std::string_view value) {
+    std::string result{"\""};
+    for (const char c : value) {
+        switch (c) {
+            case '\\':
+                result += "\\\\";
+                break;
+            case '"':
+                result += "\\\"";
+                break;
+            case '\n':
+                result += "\\n";
+                break;
+            case '\r':
+                result += "\\r";
+                break;
+            case '\t':
+                result += "\\t";
+                break;
+            default:
+                result += c;
+                break;
+        }
+    }
+    result += '"';
+    return result;
+}
+
+Result<void> validateDependencies(std::span<const Dependency> dependencies) {
+    std::unordered_map<std::string, const Dependency *> seen;
+    for (const Dependency &dependency : dependencies) {
+        if (dependency.name.empty()) {
+            return std::unexpected("A vcpkg dependency is missing its name.");
+        }
+        if (dependency.triplet.empty()) {
+            return std::unexpected(std::format("vcpkg dependency '{}' is missing its triplet.", dependency.name));
+        }
+        const std::string dependency_key = dependency.name + '\x1f' + dependency.triplet;
+        if (const auto existing = seen.find(dependency_key); existing != seen.end()) {
+            const Dependency &previous = *existing->second;
+            if (previous.version != dependency.version || previous.port_version != dependency.port_version
+                || previous.features != dependency.features) {
+                return std::unexpected(std::format(
+                    "Conflicting vcpkg declarations for '{}' in triplet '{}'.", dependency.name, dependency.triplet));
+            }
+        } else {
+            seen.emplace(dependency_key, &dependency);
+        }
+    }
+    return {};
+}
+
+Result<void> writeManifest(const fs::path &manifest_dir,
+                           std::span<const Dependency> dependencies,
+                           std::string_view builtin_baseline) {
+    auto json = manifestJson(dependencies, builtin_baseline);
+    if (!json) {
+        return std::unexpected(json.error());
+    }
+
+    std::error_code ec;
+    fs::create_directories(manifest_dir, ec);
+    if (ec) {
+        return std::unexpected(
+            std::format("Failed to create vcpkg manifest directory '{}': {}", manifest_dir.string(), ec.message()));
+    }
+
+    std::ofstream output(manifest_dir / "vcpkg.json");
+    if (!output) {
+        return std::unexpected(std::format("Failed to write vcpkg manifest in '{}'.", manifest_dir.string()));
+    }
+    output << *json;
+    return {};
+}
+
+std::optional<std::string> fieldValue(std::string_view line, std::string_view field) {
+    if (!line.starts_with(field) || line.size() <= field.size() || line[field.size()] != ':') {
+        return std::nullopt;
+    }
+    return trim(std::string(line.substr(field.size() + 1)));
+}
+
+} // namespace
+
+std::string statusKey(std::string_view name, std::string_view triplet) {
+    std::string result{name};
+    result.push_back('\x1f');
+    result += triplet;
+    return result;
+}
+
+Result<std::string> currentBuiltinBaseline(const fs::path &vcpkg_root) {
+    auto result = catalyst::processExecStdout({"git", "-C", vcpkg_root.string(), "rev-parse", "HEAD"});
+    if (!result) {
+        return std::unexpected(std::format("Failed to determine the vcpkg builtin baseline: {}", result.error()));
+    }
+    std::string baseline = trim(*result);
+    if (baseline.empty()) {
+        return std::unexpected("vcpkg returned an empty builtin baseline.");
+    }
+    return baseline;
+}
+
+Result<std::string> manifestJson(std::span<const Dependency> dependencies, std::string_view builtin_baseline) {
+    if (builtin_baseline.empty()) {
+        return std::unexpected("A vcpkg builtin baseline is required for manifest mode.");
+    }
+    if (auto valid = validateDependencies(dependencies); !valid) {
+        return std::unexpected(valid.error());
+    }
+
+    std::ostringstream output;
+    output << "{\n"
+           << "  \"name\": \"catalyst-dependencies\",\n"
+           << "  \"version-string\": \"0\",\n"
+           << "  \"builtin-baseline\": " << jsonString(builtin_baseline) << ",\n"
+           << "  \"dependencies\": [";
+
+    for (std::size_t index = 0; index < dependencies.size(); ++index) {
+        const Dependency &dependency = dependencies[index];
+        output << (index == 0 ? "\n" : ",\n") << "    ";
+        if (dependency.features.empty()) {
+            output << jsonString(dependency.name);
+        } else {
+            output << "{\"name\": " << jsonString(dependency.name) << ", \"features\": [";
+            for (std::size_t feature_index = 0; feature_index < dependency.features.size(); ++feature_index) {
+                if (feature_index != 0) {
+                    output << ", ";
+                }
+                output << jsonString(dependency.features[feature_index]);
+            }
+            output << "]}";
+        }
+    }
+    if (!dependencies.empty()) {
+        output << '\n';
+    }
+    output << "  ]";
+
+    std::vector<const Dependency *> overrides;
+    for (const Dependency &dependency : dependencies) {
+        if (!dependency.version.empty() && dependency.version != "latest") {
+            overrides.push_back(&dependency);
+        }
+    }
+    if (!overrides.empty()) {
+        output << ",\n  \"overrides\": [\n";
+        for (std::size_t index = 0; index < overrides.size(); ++index) {
+            const Dependency &dependency = *overrides[index];
+            output << "    {\"name\": " << jsonString(dependency.name)
+                   << ", \"version\": " << jsonString(dependency.version);
+            if (dependency.port_version.has_value()) {
+                output << ", \"port-version\": " << *dependency.port_version;
+            }
+            output << '}' << (index + 1 == overrides.size() ? "\n" : ",\n");
+        }
+        output << "  ]";
+    }
+    output << "\n}\n";
+    return output.str();
+}
+
+std::unordered_map<std::string, InstalledPackage> parseInstalledVersions(std::string_view status) {
+    std::unordered_map<std::string, InstalledPackage> result;
+    std::string package;
+    std::string triplet;
+    std::string version;
+    std::string state;
+    int port_version = 0;
+
+    auto flush = [&]() {
+        const bool installed =
+            state.find("installed") != std::string::npos && state.find("not-installed") == std::string::npos;
+        if (installed && !package.empty() && !triplet.empty() && !version.empty()) {
+            result[statusKey(package, triplet)] = InstalledPackage{.version = version, .port_version = port_version};
+        }
+        package.clear();
+        triplet.clear();
+        version.clear();
+        state.clear();
+        port_version = 0;
+    };
+
+    std::size_t position = 0;
+    while (position <= status.size()) {
+        const std::size_t newline = status.find('\n', position);
+        const std::size_t end = newline == std::string_view::npos ? status.size() : newline;
+        const std::string_view line = status.substr(position, end - position);
+        if (trim(std::string(line)).empty()) {
+            flush();
+        } else if (auto value = fieldValue(line, "Package")) {
+            package = *value;
+        } else if (auto value = fieldValue(line, "Architecture")) {
+            triplet = *value;
+        } else if (auto value = fieldValue(line, "Version")) {
+            version = *value;
+        } else if (auto value = fieldValue(line, "Port-Version")) {
+            try {
+                port_version = std::stoi(*value);
+            } catch (...) {
+                port_version = 0;
+            }
+        } else if (auto value = fieldValue(line, "Status")) {
+            state = *value;
+        }
+
+        if (newline == std::string_view::npos) {
+            break;
+        }
+        position = newline + 1;
+    }
+    flush();
+    return result;
+}
+
+Result<InstallResult> install(std::span<const Dependency> dependencies,
+                              const fs::path &build_dir,
+                              const std::optional<std::string> &builtin_baseline) {
+    if (dependencies.empty()) {
+        return InstallResult{};
+    }
+    if (auto valid = validateDependencies(dependencies); !valid) {
+        return std::unexpected(valid.error());
+    }
+
+    const char *vcpkg_root_env = std::getenv("VCPKG_ROOT");
+    if (vcpkg_root_env == nullptr) {
+        return std::unexpected(
+            "VCPKG_ROOT environment variable not set. Please set it to your vcpkg installation directory.");
+    }
+    const fs::path vcpkg_root{vcpkg_root_env};
+    fs::path vcpkg_executable = vcpkg_root / "vcpkg";
+#if defined(_WIN32)
+    vcpkg_executable.replace_extension(".exe");
+#endif
+
+    std::string baseline;
+    if (builtin_baseline && !builtin_baseline->empty()) {
+        baseline = *builtin_baseline;
+    } else {
+        auto resolved_baseline = currentBuiltinBaseline(vcpkg_root);
+        if (!resolved_baseline) {
+            return std::unexpected(resolved_baseline.error());
+        }
+        baseline = *resolved_baseline;
+    }
+
+    std::map<std::string, std::vector<Dependency>> by_triplet;
+    for (const Dependency &dependency : dependencies) {
+        by_triplet[dependency.triplet].push_back(dependency);
+    }
+
+    const fs::path install_root = build_dir / "vcpkg_installed";
+    for (const auto &[triplet, triplet_dependencies] : by_triplet) {
+        const fs::path manifest_dir = build_dir / "vcpkg-manifests" / triplet;
+        if (auto written = writeManifest(manifest_dir, triplet_dependencies, baseline); !written) {
+            return std::unexpected(written.error());
+        }
+
+        std::vector<std::string> args = {vcpkg_executable.string(),
+                                         "install",
+                                         "--x-manifest-root=" + manifest_dir.string(),
+                                         "--x-install-root=" + install_root.string(),
+                                         "--triplet=" + triplet};
+        auto process = catalyst::processExec(std::move(args));
+        if (!process) {
+            return std::unexpected(std::format("Failed to start vcpkg manifest installation: {}", process.error()));
+        }
+        if (process->get() != 0) {
+            return std::unexpected(std::format("vcpkg manifest installation failed for triplet '{}'.", triplet));
+        }
+    }
+
+    const fs::path status_path = install_root / "vcpkg" / "status";
+    std::ifstream status_file(status_path);
+    if (!status_file) {
+        return std::unexpected(
+            std::format("vcpkg did not produce an installed status file at '{}'.", status_path.string()));
+    }
+    std::stringstream status;
+    status << status_file.rdbuf();
+    return InstallResult{
+        .builtin_baseline = baseline, .install_root = install_root, .packages = parseInstalledVersions(status.str())};
+}
+
+} // namespace catalyst::utils::vcpkg

--- a/src/utils/yaml/configuration.cpp
+++ b/src/utils/yaml/configuration.cpp
@@ -214,6 +214,7 @@ void validateProfileKeys(ryml::ConstNodeRef profile, const std::string &profile_
                         "triplet",
                         "using",
                         "linkage",
+                        "transitive",
                         "path",
                         "url",
                         "profiles",

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -125,6 +125,86 @@ def test_init_and_build(tmp_path):
     assert run_result.returncode == 0
     assert "Hello, Catalyst!" in run_result.stdout
 
+def test_inherited_toolchain_change_regenerates_build_files(tmp_path):
+    project_dir = tmp_path / "toolchain_regeneration"
+    project_dir.mkdir()
+    (project_dir / "src").mkdir()
+
+    profile_path = project_dir / "catalyst.yaml"
+    profile_path.write_text("""meta:
+  generator: cob
+manifest:
+  name: toolchain_regeneration
+  type: BINARY
+  toolchain: child.yaml
+  dirs:
+    source: [src]
+    include: []
+    build: build
+""")
+    (project_dir / "src" / "main.cpp").write_text("int main() { return 0; }\n")
+    (project_dir / "child.yaml").write_text("""toolchain:
+  extends: base.yaml
+""")
+    base_toolchain = project_dir / "base.yaml"
+    base_toolchain.write_text("""toolchain:
+  compiler:
+    cxx:
+      flags: -DISSUE88_OLD
+""")
+
+    first_build = subprocess.run(
+        [str(CATALYST_BIN), "build"], cwd=project_dir, capture_output=True, text=True)
+    assert first_build.returncode == 0, first_build.stderr
+
+    build_file = project_dir / "build" / "common" / "catalyst.build"
+    toolchain_store = project_dir / "build" / "common" / "catalyst__tc_store"
+    assert build_file.exists()
+    assert toolchain_store.exists()
+    assert "ISSUE88_OLD" in build_file.read_text()
+    stored_toolchain = toolchain_store.read_text()
+    assert "ISSUE88_OLD" in stored_toolchain
+    assert "extends" not in stored_toolchain
+    assert 'command: "{archiver} rcs {output} {objects}"' in stored_toolchain
+
+    # Only an inherited base file changes; no manifest timestamp can trigger regeneration.
+    base_toolchain.write_text("""toolchain:
+  compiler:
+    cxx:
+      flags: -DISSUE88_NEW
+""")
+    second_build = subprocess.run(
+        [str(CATALYST_BIN), "build"], cwd=project_dir, capture_output=True, text=True)
+    assert second_build.returncode == 0, second_build.stderr
+    assert "Generating build files." in second_build.stdout + second_build.stderr
+    assert "ISSUE88_NEW" in build_file.read_text()
+    assert "ISSUE88_OLD" not in build_file.read_text()
+    assert "ISSUE88_NEW" in toolchain_store.read_text()
+
+    build_file_mtime = build_file.stat().st_mtime_ns
+    stored_toolchain = toolchain_store.read_text()
+    # Formatting and comments change, but the fully resolved definition does not.
+    base_toolchain.write_text("""# equivalent toolchain
+toolchain:
+  compiler:
+    cxx:
+      flags: "-DISSUE88_NEW"
+""")
+    third_build = subprocess.run(
+        [str(CATALYST_BIN), "build"], cwd=project_dir, capture_output=True, text=True)
+    assert third_build.returncode == 0, third_build.stderr
+    assert "Generating build files." not in third_build.stdout + third_build.stderr
+    assert build_file.stat().st_mtime_ns == build_file_mtime
+    assert toolchain_store.read_text() == stored_toolchain
+
+    # An unchanged toolchain still falls through to the existing profile timestamp check.
+    newer_profile_time = build_file_mtime + 2_000_000_000
+    os.utime(profile_path, ns=(newer_profile_time, newer_profile_time))
+    fourth_build = subprocess.run(
+        [str(CATALYST_BIN), "build"], cwd=project_dir, capture_output=True, text=True)
+    assert fourth_build.returncode == 0, fourth_build.stderr
+    assert "Generating build files." in fourth_build.stdout + fourth_build.stderr
+
 def test_invalid_yaml_handles_gracefully(tmp_path):
     project_dir = tmp_path / "bad_project"
     project_dir.mkdir()
@@ -285,4 +365,3 @@ def test_add_conan(tmp_path):
     assert "source: conan" in yaml_content
     assert "name: fmt" in yaml_content
     assert "version: 10.1.1" in yaml_content
-

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -16,6 +16,13 @@ TEST_CASE("Basic Check", "[basic]") {
     REQUIRE(1 == 1);
 }
 
+TEST_CASE("Generator build filenames", "[generate]") {
+    REQUIRE(catalyst::generate::buildFilename("cob") == "catalyst.build");
+    REQUIRE(catalyst::generate::buildFilename("ninja") == "build.ninja");
+    REQUIRE(catalyst::generate::buildFilename("make") == "Makefile");
+    REQUIRE(catalyst::generate::buildFilename("gmake") == "Makefile");
+}
+
 class MockProcessExecutor : public catalyst::IProcessExecutor {
 public:
     std::vector<std::vector<std::string>> executed_commands;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -9,6 +9,7 @@
 #include "catalyst/subcommands/fetch.hpp"
 #include "catalyst/subcommands/generate.hpp"
 #include "catalyst/utils/os/os_defs.hpp"
+#include "catalyst/utils/vcpkg.hpp"
 #include "catalyst/utils/yaml/ryml_init.hpp"
 #include "catalyst/utils/yaml/ryml_utils.hpp"
 
@@ -348,6 +349,109 @@ Status: install ok installed
 
     // not-installed stanzas are skipped entirely.
     REQUIRE_FALSE(db.depends.contains(vcpkgStatusKey("removed-pkg", "x64-linux")));
+}
+
+TEST_CASE("vcpkg manifest generation pins exact versions and preserves features", "[vcpkg][manifest]") {
+    using catalyst::utils::vcpkg::Dependency;
+    const std::vector<Dependency> dependencies = {
+        {.name = "raylib", .version = "4.5.0", .triplet = "x64-linux", .features = {"use-audio"}, .port_version = 2},
+        {.name = "zlib", .version = "latest", .triplet = "x64-linux", .features = {}, .port_version = std::nullopt},
+    };
+
+    auto manifest = catalyst::utils::vcpkg::manifestJson(dependencies, "903956eff7cb94774a9e805ff573c000afc43e3e");
+
+    REQUIRE(manifest.has_value());
+    CHECK(manifest->find("\"builtin-baseline\": \"903956eff7cb94774a9e805ff573c000afc43e3e\"") != std::string::npos);
+    CHECK(manifest->find("{\"name\": \"raylib\", \"features\": [\"use-audio\"]}") != std::string::npos);
+    CHECK(manifest->find("{\"name\": \"raylib\", \"version\": \"4.5.0\", \"port-version\": 2}") != std::string::npos);
+    CHECK(manifest->find("{\"name\": \"zlib\", \"version\"") == std::string::npos);
+}
+
+TEST_CASE("vcpkg installed status parsing records resolved versions and port revisions", "[vcpkg][manifest]") {
+    constexpr std::string_view status = R"(Package: raylib
+Version: 4.5.0
+Port-Version: 2
+Architecture: x64-linux
+Status: install ok installed
+
+Package: raylib
+Feature: use-audio
+Version: 4.5.0
+Port-Version: 2
+Architecture: x64-linux
+Status: install ok installed
+
+Package: removed
+Version: 1.0.0
+Architecture: x64-linux
+Status: purge ok not-installed
+)";
+
+    auto packages = catalyst::utils::vcpkg::parseInstalledVersions(status);
+
+    REQUIRE(packages.size() == 1);
+    const auto &raylib = packages.at(catalyst::utils::vcpkg::statusKey("raylib", "x64-linux"));
+    CHECK(raylib.version == "4.5.0");
+    CHECK(raylib.port_version == 2);
+}
+
+TEST_CASE("vcpkg manifest installation uses a profile-local install root", "[vcpkg][manifest]") {
+    namespace fs = std::filesystem;
+    using catalyst::utils::vcpkg::Dependency;
+
+    const fs::path temp_root = fs::temp_directory_path() / "catalyst_test_vcpkg_manifest_install";
+    const fs::path build_dir = temp_root / "build";
+    const fs::path status_path = build_dir / "vcpkg_installed" / "vcpkg" / "status";
+    fs::remove_all(temp_root);
+    fs::create_directories(status_path.parent_path());
+    {
+        std::ofstream status(status_path);
+        status << "Package: raylib\n"
+                  "Version: 4.5.0\n"
+                  "Port-Version: 2\n"
+                  "Architecture: x64-linux\n"
+                  "Status: install ok installed\n";
+    }
+
+    const char *original_vcpkg_root = std::getenv("VCPKG_ROOT");
+    const std::optional<std::string> saved_vcpkg_root =
+        original_vcpkg_root == nullptr ? std::nullopt : std::optional<std::string>{original_vcpkg_root};
+#ifdef _WIN32
+    _putenv_s("VCPKG_ROOT", (temp_root / "vcpkg").string().c_str());
+#else
+    setenv("VCPKG_ROOT", (temp_root / "vcpkg").string().c_str(), 1);
+#endif
+
+    auto mock_executor = std::make_shared<MockProcessExecutor>();
+    catalyst::setProcessExecutor(mock_executor);
+    const std::vector<Dependency> dependencies = {
+        {.name = "raylib", .version = "4.5.0", .triplet = "x64-linux", .features = {}, .port_version = 2},
+    };
+
+    auto installed = catalyst::utils::vcpkg::install(
+        dependencies, build_dir, std::string{"903956eff7cb94774a9e805ff573c000afc43e3e"});
+
+    REQUIRE(installed.has_value());
+    REQUIRE(mock_executor->executed_commands.size() == 1);
+    const auto &command = mock_executor->executed_commands.front();
+    CHECK(command[1] == "install");
+    CHECK(std::ranges::find(command, "--x-manifest-root=" + (build_dir / "vcpkg-manifests/x64-linux").string())
+          != command.end());
+    CHECK(std::ranges::find(command, "--x-install-root=" + (build_dir / "vcpkg_installed").string()) != command.end());
+    CHECK(std::ranges::find(command, "--triplet=x64-linux") != command.end());
+    CHECK(installed->packages.at(catalyst::utils::vcpkg::statusKey("raylib", "x64-linux")).version == "4.5.0");
+
+    catalyst::setProcessExecutor(std::make_shared<catalyst::ProcessExecutor>());
+#ifdef _WIN32
+    _putenv_s("VCPKG_ROOT", saved_vcpkg_root.value_or("").c_str());
+#else
+    if (saved_vcpkg_root) {
+        setenv("VCPKG_ROOT", saved_vcpkg_root->c_str(), 1);
+    } else {
+        unsetenv("VCPKG_ROOT");
+    }
+#endif
+    fs::remove_all(temp_root);
 }
 
 TEST_CASE("vcpkgTransitiveClosure resolves and orders dependencies", "[vcpkg]") {

--- a/tests/test_toolchain.cpp
+++ b/tests/test_toolchain.cpp
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <fstream>
+#include <optional>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -7,7 +8,8 @@
 #include "catalyst/utils/yaml/configuration.hpp"
 
 namespace catalyst::toolchain {
-inline std::string expand_template(std::string_view tmpl, const std::unordered_map<std::string_view, std::string> &vars) {
+inline std::string expand_template(std::string_view tmpl,
+                                   const std::unordered_map<std::string_view, std::string> &vars) {
     return expandTemplate(tmpl, vars);
 }
 inline Result<ToolchainDef> parse_toolchain(const std::filesystem::path &path) {
@@ -152,6 +154,130 @@ toolchain:
     REQUIRE(tc.extensions.shell_scripts == std::vector<std::string>{".bat"});
 
     std::filesystem::remove(temp_yaml);
+}
+
+TEST_CASE("Resolved toolchain serialization is deterministic and complete", "[toolchain]") {
+    namespace fs = std::filesystem;
+
+    ToolchainDef tc;
+    tc.name = "custom \"snapshot\"\\path\nnext-line";
+    tc.extensions.object = ".object";
+    tc.extensions.executable = ".executable";
+    tc.extensions.static_lib = ".static";
+    tc.extensions.shared_lib = ".shared";
+    tc.extensions.static_lib_prefix = "static-";
+    tc.extensions.shared_lib_prefix = "shared-";
+    tc.extensions.cpp_sources = {".cpp-custom"};
+    tc.extensions.headers = {".header-custom"};
+    tc.extensions.c_sources = {".c-custom"};
+    tc.extensions.module_interfaces = {".module-custom"};
+    tc.extensions.clang_modules = {".clang-module-custom"};
+    tc.extensions.bmi = ".bmi-custom";
+    tc.extensions.library_scan = {".library-custom"};
+    tc.extensions.shell_scripts = {".shell-custom", ".shell\\windows"};
+    tc.flags.include_dir = "include {path}";
+    tc.flags.lib_dir = "lib-dir {path}";
+    tc.flags.lib = "lib {name}";
+    tc.flags.define = "define {name} {value}";
+    tc.flags.define_empty = "define {name}";
+    tc.compiler.c = {.executable = "custom-cc", .flags = "custom-c-flags", .command = "custom\tc command"};
+    tc.compiler.cxx = {.executable = "custom-cxx", .flags = "custom-cxx-flags", .command = "custom cxx command"};
+    tc.linker.executable = "custom-linker";
+    tc.linker.flags = "custom-linker-flags";
+    tc.linker.executable_command = "custom executable link command";
+    tc.linker.shared_lib_command = "custom shared link command";
+    tc.archiver.executable = "custom-archiver";
+    tc.archiver.command = "custom archive command";
+
+    const std::string serialized = serializeToolchain(tc);
+    REQUIRE(serializeToolchain(tc) == serialized);
+    REQUIRE(serialized.find("extends") == std::string::npos);
+    REQUIRE(serializeToolchainStore(tc, "cob") != serializeToolchainStore(tc, "ninja"));
+
+    const fs::path temp_dir = fs::temp_directory_path() / "catalyst_resolved_toolchain_serialization";
+    fs::remove_all(temp_dir);
+    fs::create_directories(temp_dir);
+    const fs::path snapshot_path = temp_dir / RESOLVED_TOOLCHAIN_STORE_FILENAME;
+    {
+        std::ofstream snapshot{snapshot_path};
+        snapshot << serializeToolchainStore(tc, "cob");
+    }
+
+    auto reparsed = parseToolchain(snapshot_path);
+    REQUIRE(reparsed.has_value());
+    REQUIRE(*reparsed == tc);
+
+    auto defaults = resolveToolchain(std::nullopt);
+    REQUIRE(defaults.has_value());
+    REQUIRE_FALSE(defaults->extensions.library_scan.empty());
+    {
+        std::ofstream snapshot{snapshot_path};
+        snapshot << serializeToolchain(*defaults);
+    }
+    auto reparsed_defaults = parseToolchain(snapshot_path);
+    REQUIRE(reparsed_defaults.has_value());
+    REQUIRE(*reparsed_defaults == *defaults);
+    fs::remove_all(temp_dir);
+}
+
+TEST_CASE("Resolved toolchain serialization compares effective inheritance", "[toolchain]") {
+    namespace fs = std::filesystem;
+
+    const fs::path temp_dir = fs::temp_directory_path() / "catalyst_resolved_toolchain_inheritance";
+    fs::remove_all(temp_dir);
+    fs::create_directories(temp_dir);
+
+    const fs::path base_path = temp_dir / "base.yaml";
+    const fs::path child_path = temp_dir / "child.yaml";
+    {
+        std::ofstream base{base_path};
+        base << R"(toolchain:
+  compiler:
+    cxx:
+      executable: clang++
+      flags: -O2
+)";
+        std::ofstream child{child_path};
+        child << R"(toolchain:
+  extends: base.yaml
+  compiler:
+    cxx:
+      flags: -O0
+)";
+    }
+
+    auto original = parseToolchain(child_path);
+    REQUIRE(original.has_value());
+    const std::string original_snapshot = serializeToolchain(*original);
+
+    // The changed base flag is overridden by the leaf, so the effective toolchain is unchanged.
+    {
+        std::ofstream base{base_path};
+        base << R"(toolchain:
+  compiler:
+    cxx:
+      executable: "clang++"
+      flags: "-O3"
+)";
+    }
+    auto equivalent = parseToolchain(child_path);
+    REQUIRE(equivalent.has_value());
+    REQUIRE(serializeToolchain(*equivalent) == original_snapshot);
+
+    // The compiler executable is inherited, so changing it changes the effective snapshot.
+    {
+        std::ofstream base{base_path};
+        base << R"(toolchain:
+  compiler:
+    cxx:
+      executable: g++
+      flags: -O3
+)";
+    }
+    auto changed = parseToolchain(child_path);
+    REQUIRE(changed.has_value());
+    REQUIRE(serializeToolchain(*changed) != original_snapshot);
+    fs::remove_all(temp_dir);
 }
 
 TEST_CASE("Configuration preserves manifest.toolchain", "[toolchain][configuration]") {

--- a/tests/test_yaml_characterization.cpp
+++ b/tests/test_yaml_characterization.cpp
@@ -165,6 +165,31 @@ TEST_CASE("Profile composition: scalar override, sequence append, dependency app
     CHECK(yaml::asString(yaml::child(deps[1], "name")) == "zlib");
 }
 
+TEST_CASE("Profile composition: vcpkg transitive booleans survive dependency composition",
+          "[yaml][characterization]") {
+    TempDir dir{"catalyst_char_vcpkg_transitive"};
+    writeFile(dir.path / "CATALYST.yaml",
+              R"(common:
+  dependencies:
+    - name: fmt
+      source: vcpkg
+      transitive: true
+    - name: zlib
+      source: vcpkg
+      transitive: false
+)");
+
+    Configuration config({"common"}, dir.path);
+
+    namespace yaml = catalyst::utils::yaml;
+    ryml::ConstNodeRef deps = yaml::child(config.rootRef(), "dependencies");
+    REQUIRE(deps.readable());
+    REQUIRE(deps.is_seq());
+    REQUIRE(deps.num_children() == 2);
+    CHECK(yaml::asBool(yaml::child(deps[0], "transitive")) == true);
+    CHECK(yaml::asBool(yaml::child(deps[1], "transitive")) == false);
+}
+
 TEST_CASE("Profile composition: min_ver takes the maximum version seen", "[yaml][characterization]") {
     TempDir dir{"catalyst_char_minver"};
     writeFile(dir.path / "CATALYST.yaml", kCompositionYaml);


### PR DESCRIPTION
- **fix: issue #88**
- **fix: update docs**
- **fix: an issue with specifying transitive under a vcpkg dependency**
- **fix: version bump while developing**
- **feat(vcpkg): add manifest generation and install primitives**
- **feat(fetch): install vcpkg dependencies from generated manifests**
- **feat(lock): record resolved vcpkg versions and registry baseline**
- **feat(generate): resolve vcpkg artifacts from profile-local installs**
- **docs(vcpkg): document manifest-mode version guarantees**
- **add: support policy**
- **feat: allow specifying profile composition for fmt**
